### PR TITLE
Noetcd

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ daemons, however, this feature is planned for the future.
 ## Dependencies
 etcd3 can be downlaoded via pip3, or from source at:
 https://github.com/etcd-io/etcd
+It is not required if only configuration file generation with
+maestro_ctrl is required.
 
 ## Configuration Generation
 A ldms cluster's configuration can be generated with the maestro_ctrl
@@ -48,7 +50,7 @@ There are two principle commands, maestro and maestro_ctrl. maestro will run the
 
     maestro --cluster config/etcd.yaml --prefix orion
 
-    maestro_ctrl --cluster config/etcd.yaml --ldms_config config/orion.yaml --prefix orion
+    maestro_ctrl --etcd --cluster config/etcd.yaml --ldms_config config/orion.yaml --prefix orion
 
 Sampler interval's and offsets can be configured during runtime, by updating the ldmsd yaml
 configuration file, and running the maestro_ctrl command to update the etcd cluster with the
@@ -73,6 +75,7 @@ members:
   - host: 10.128.0.9
     port: 2379
 ```
+No 'members:' declarations are required if etcd is not in use.
 
 And here is an example of a LDMS Cluster Configuration File:
 

--- a/maestro_ctrl
+++ b/maestro_ctrl
@@ -5,10 +5,11 @@ import yaml
 import hostlist
 import collections
 import argparse
-import etcd3
 import json
 import time
 from collections import Mapping, Sequence
+from noetcd import NoetcdClient
+from noetcd import MaestroBooleanOptionalAction
 
 class Cluster(object):
     def emit_value(self, path, value):
@@ -538,6 +539,7 @@ def cvt_intrvl_str_to_us(interval_s):
         raise ValueError(f"{interval_s} is not a valid time-interval string")
     return int(mult * factor)
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="LDMS Monitoring Cluster Configuration")
@@ -552,6 +554,9 @@ if __name__ == "__main__":
                         default="unknown")
     parser.add_argument("--generate-config-path", metavar="STRING", required=False,
                         default=False)
+    parser.add_argument("--etcd", action=MaestroBooleanOptionalAction,
+                        help="Enable transmission to etcd (default: no)");
+    parser.add_argument("--debug", action=MaestroBooleanOptionalAction);
     parser.add_argument("--version", metavar="VERSION",
                         help="The OVIS version for the output syntax (4 or 5), default is 4",
                         default=4)
@@ -563,9 +568,10 @@ if __name__ == "__main__":
     etcd_spec = yaml.safe_load(etcd_fp)
 
     pfx = etcd_spec['cluster']
-    etcd_hosts = ()
-    for h in etcd_spec['members']:
-        etcd_hosts += (( h['host'], h['port'] ),)
+    if args.etcd:
+        etcd_hosts = ()
+        for h in etcd_spec['members']:
+            etcd_hosts += (( h['host'], h['port'] ),)
 
     # All keys in the DB are prefixed with the cluster name, 'pfx'. So we can
     # have multiple monitoring hosted by the same consensus cluster.
@@ -573,9 +579,13 @@ if __name__ == "__main__":
     conf_spec = yaml.safe_load(config_fp)
 
     # Use the 1st host for now
-    client = etcd3.client(host=etcd_hosts[0][0], port=etcd_hosts[0][1],
+    if args.etcd:
+        import etcd3
+        client = etcd3.client(host=etcd_hosts[0][0], port=etcd_hosts[0][1],
         grpc_options=[ ('grpc.max_send_message_length',16*1024*1024),
                        ('grpc.max_receive_message_length',16*1024*1024)])
+    else:
+        client = NoetcdClient()
 
     cluster = Cluster(client, args.prefix, conf_spec)
     if args.generate_config_path:
@@ -589,5 +599,7 @@ if __name__ == "__main__":
         print("Error saving ldms cluster configuration to etcd cluster")
         sys.exit(0)
     print("LDMS aggregator configuration saved to etcd cluster.")
+    if not args.etcd and args.debug:
+        client.print_all()
 
     sys.exit(0)

--- a/noetcd.py
+++ b/noetcd.py
@@ -1,0 +1,69 @@
+#! /usr/bin/env python3
+
+class NoetcdClient(object):
+    """Local-use-only, go-free replacement for etcd3 as used in maestro_ctrl."""
+    def __init__(self):
+        self.noetc = True
+        self.d = dict()
+    def put(self, path, val):
+        self.d[path] = val
+    def delete_prefix(self, p):
+        kill = list(filter(lambda x: x.startswith(p), self.d.keys()))
+        for k in kill:
+            self.d.pop(k)
+    def print_all(self):
+        for i in self.d.items():
+            print(i)
+    def test(self):
+        self.put("bob", "1")
+        self.put("/bar", "1")
+        self.put("/foo", "1")
+        print(self.d)
+        self.delete_prefix("/")
+        print(self.d)
+
+import argparse
+class MaestroBooleanOptionalAction(argparse.Action):
+    """backported from python 3.9 argparse"""
+    def __init__(self,
+                 option_strings,
+                 dest,
+                 default=None,
+                 type=None,
+                 choices=None,
+                 required=False,
+                 help=None,
+                 metavar=None):
+
+        _option_strings = []
+        for option_string in option_strings:
+            _option_strings.append(option_string)
+
+            if option_string.startswith('--'):
+                option_string = '--no-' + option_string[2:]
+                _option_strings.append(option_string)
+
+        if help is not None and default is not None:
+            help += " (default: %(default)s)"
+
+        super().__init__(
+            option_strings=_option_strings,
+            dest=dest,
+            nargs=0,
+            default=default,
+            type=type,
+            choices=choices,
+            required=required,
+            help=help,
+            metavar=metavar)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if option_string in self.option_strings:
+            setattr(namespace, self.dest, not option_string.startswith('--no-'))
+
+    def format_usage(self):
+        return ' | '.join(self.option_strings)
+
+if __name__ == "__main__":
+    n = NoetcdClient()
+    n.test()


### PR DESCRIPTION
 Use of etcd option in maestro_ctrl, enable with: --etcd
    
 When generating files (as for rhel7/toss3) instead of feeding  an etcd insertion, the etcd run/go-lang build dependences are not required.
    
This includes a backport from python 3.9 of the BooleanOptionalAction in a way which will not conflict with py 3.9.
