### PR TITLE
add ~{} substitution for support of ldms config patterns

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -1,0 +1,211 @@
+mycluster : cluster1
+hpfx      : cl
+endpoints:
+  - names : &compute "~{hpfx}[1-288]-411"
+    group : samplers
+    hosts : &compute-hosts "~{hpfx}[1-288]-ib0"
+    ports : &compute-ports "411"
+    xprt : rdma
+    auth :
+      name  : ovis
+      config  :
+        domain : samplers
+
+  - names : &login "~{mycluster}-login[1-3]-411"
+    group : samplers
+    hosts : &login-hosts "~{mycluster}-login[1-3]-ib0"
+    ports : &login-ports "411"
+    xprt : rdma
+    auth :
+      name  : ovis
+      config  :
+        domain : samplers
+
+  - names : &lustre-oss "~{hpfx}oss[1-4]-411"
+    group : samplers
+    hosts : &lustre-oss-hosts "~{hpfx}oss[1-4]-ib0"
+    ports : &lustre-oss-ports "411"
+    xprt : rdma
+    auth :
+      name  : ovis
+      config  :
+        domain : samplers
+
+  - names : &lustre-mds "~{hpfx}mds[1-2]-411"
+    group : samplers
+    hosts : &lustre-mds-hosts "~{hpfx}mds[1-2]-ib0"
+    ports : &lustre-mds-ports "411"
+    xprt : rdma
+    auth :
+      name  : ovis
+      config  :
+        domain : samplers
+
+  - names : &admin "~{hpfx}ldms1,~{hpfx}admin[1-3]-411"
+    group : samplers
+    hosts : &admin-hosts "~{hpfx}ldms1-ib0,~{hpfx}admin[1-3]-ib0"
+    ports : &admin-ports "411"
+    xprt : rdma
+    auth :
+      name  : ovis
+      config  :
+        domain : samplers
+
+  - names : &l1-agg-endpoints "~{hpfx}ldms1" 
+    group : &l1-agg "l1-agg"
+    hosts : &agg-host "~{hpfx}ldms1"
+    ports : "413"
+    xprt : sock
+    auth :
+      name  : ovis
+      config  :
+        domain : aggregators
+
+groups:
+  - endpoints : [*admin,*lustre-mds,*lustre-oss,*login,*compute]
+    name : samplers
+    interfaces : 
+      - [*compute,*login,*lustre-oss,*lustre-mds,*admin]
+
+  - endpoints : *l1-agg-endpoints
+    name : *l1-agg
+    interfaces : 
+      - [*admin,*lustre-mds,*lustre-oss,*login,*compute]
+      - *l1-agg-endpoints
+
+aggregators:
+  - names     : *l1-agg-endpoints
+    endpoints : *l1-agg-endpoints
+    group     : *l1-agg
+
+producers:
+  - names     : *admin
+    endpoints : *admin
+    #- names     : [*admin,*lustre-mds,*lustre-oss,*login,*compute]
+    # endpoints : [*admin,*lustre-mds,*lustre-oss,*login,*compute]
+    group     : *l1-agg
+    reconnect : 20s
+    type      : active
+    updaters  :
+      - l1-all
+
+samplers:
+  # - names       : [*admin,*lustre-mds,*lustre-oss,*login,*compute]
+  - names       : *admin
+    group : samplers
+    sampler_config_defaults: &sampler-defaults
+        plugin      : plugin_unset
+        name        : ~{plugin}
+        schema      : ~{plugin}
+        job_set     : ${host}/jobid
+        instance    : ${HOSTNAME}/~{name}
+        component_id: ${COMPONENT_ID}
+        interval    : 1000000
+        offset      : 0
+        perm        : "0644"
+
+    config :
+      - <<: *sampler-defaults
+        plugin      : jobid
+        file        : /var/run/ldms.slurm.jobinfo
+      - <<: *sampler-defaults
+        plugin      : meminfo
+      - <<: *sampler-defaults
+        plugin      : vmstat
+      - <<: *sampler-defaults
+        plugin      : procstat
+        schema      : procstat_~{maxcpu}
+        maxcpu      : 72
+      - <<: *sampler-defaults
+        plugin      : loadavg
+        metrics     : load1min,load5min,load15min,runnable,scheduling_entities
+        interval    : 10000000
+      - <<: *sampler-defaults
+        plugin      : filesingle
+        interval    : 5000000
+        schema      : filesingle_{mycluster} 
+        conf        : /etc/sysconfig/ldms.d/plugins-conf/filesingle.data.login
+        timing      : keyword
+      - <<: *sampler-defaults
+        plugin      : tx2mon 
+        auto-schema : 1
+        array       : 1
+        extra       : 1
+      - <<: *sampler-defaults
+        plugin      : dstat
+        io          : 1
+        stat        : 1
+        statm       : 1
+        fdtypes     : 1
+        auto-schema : 1
+      - <<: *sampler-defaults
+        plugin      : procnet
+      - <<: *sampler-defaults
+        plugin      : sysclassib
+      - <<: *sampler-defaults
+        plugin      : procnfs
+      - <<: *sampler-defaults
+        plugin      : lnet_stats
+      - <<: *sampler-defaults
+        plugin      : llnl_lustre_client
+        schema      : lustre_client
+
+updaters:            
+- name  : all           # must be unique within group
+  group : *l1-agg
+  interval : "1.0s:0ms"
+  sets :
+    - regex : .*        # regular expression matching set name or schema
+      field : inst      # 'instance' or 'schema'
+  producers :
+    - regex : .*        # regular expression matching producer name
+                        # this is evaluated on the Aggregator, not
+                        # at configuration time'
+
+store_config_defaults_csv: &store-defaults-csv
+  - schema    : schema_unset
+    name      : csv-~{schema}
+    group     : *l1-agg
+    container : store_csv
+    plugin :
+      name   : store_csv
+      config :
+        path : /ldmslocal/store
+        altheader   : 0
+        typeheader  : 1
+        create_uid  : 3031
+        create_gid  : 3031
+
+stores :
+  - <<: *store-defaults-csv
+    schema    : meminfo
+  - <<: *store-defaults-csv
+    schema    : vmstat
+  - <<: *store-defaults-csv
+    schema    : procstat
+  - <<: *store-defaults-csv
+    schema     : jobid
+  - <<: *store-defaults-csv
+    schema      : meminfo
+  - <<: *store-defaults-csv
+    schema      : vmstat
+  - <<: *store-defaults-csv
+    schema      : procstat
+  - <<: *store-defaults-csv
+    schema      : loadavg
+  - <<: *store-defaults-csv
+    schema      : filesingle
+  - <<: *store-defaults-csv
+    schema      : tx2mon 
+  - <<: *store-defaults-csv
+    schema      : dstat
+  - <<: *store-defaults-csv
+    schema      : procnet
+  - <<: *store-defaults-csv
+    schema      : sysclassib
+  - <<: *store-defaults-csv
+    schema      : procnfs
+  - <<: *store-defaults-csv
+    schema      : lnet_stats
+  - <<: *store-defaults-csv
+    schema      : lustre_client

--- a/maestro_ctrl
+++ b/maestro_ctrl
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import os, sys
+import os, sys, traceback
 import errno
 import yaml
 import hostlist
@@ -8,7 +8,69 @@ import argparse
 import etcd3
 import json
 import time
+import re
+import copy
 from collections import Mapping, Sequence
+
+class TildeSubs(object):
+    """manage a stack of dicts for ~{} expansion"""
+    def __init__(self):
+        self.stack = []
+        self.push(dict())
+        self.re = re.compile(r'~\{[^~{}]+\}')
+    def push(self, d):
+        """stash current dict."""
+        self.stack.append(d)
+    def pop(self):
+        del self.stack[-1]
+    def get_val(self, key):
+        """reverse search on stack for closest value of the key.
+           If nothing is found, returns False.
+           If empty string is found, returns None."""
+        for i in range(len(self.stack) -1, -1, -1):
+            if key in self.stack[i]:
+                return self.stack[i][key]
+        return False
+    def expand_val(self, val, debug=False):
+        """ DFBU substitution on a string. Returns (changed, newval)"""
+        if debug:
+            print("searching value: {}\n".format(val))
+        newval = ""
+        last = 0
+        changed = False
+        for m in self.re.finditer(val):
+            newval += val[last:m.start()]
+            last = m.end()
+            var = m.string[m.start():m.end()][2:-1]
+            if debug:
+                print("containing: {}\n".format(var))
+            s = self.get_val(var)
+            if s:
+                changed = True
+                newval += str(s)
+                if debug:
+                    print("replaced with: {}\n".format(s))
+            else:
+                if not isinstance(s, bool):
+                    changed = True
+                    if debug:
+                        print("empty replace: {}\n".format(var))
+                else:
+                    if debug:
+                        print("undefined: {}\n".format(var))
+        newval += val[last:]
+        return (changed, newval)
+    def expand_key(self, key, debug=False):
+        """ DFBU substitution on a key in deepest current dict"""
+        if debug:
+            print("checking: {}\n".format(key))
+        val = self.stack[-1][key]
+        (changed, newval) = self.expand_val(val, debug)
+        if changed:
+            if debug:
+                print("key updated: {} : {}\n".format(key, newval))
+            self.stack[-1][key] = newval
+        return changed
 
 class Cluster(object):
     def emit_value(self, path, value):
@@ -16,6 +78,46 @@ class Cluster(object):
             res = client.put(path, str(value))
         except Exception as e:
             print("Error {0} setting {1} : {2}".format(str(e), path, str(value)))
+
+    def walk_tilde(self, obj, subs=None, debug=False):
+        """Walk the obj given and apply ~{} string replacement in place.
+           In scalar values, ~{var} is replaced by its value if
+           var is the name of scalar value at the same or higher scope.
+           This provides us the ability to say:
+           cluster: foo
+           config:
+             - plugin: bar
+             - inst: ~{cluster}/${HOSTNAME}/~{plugin}
+           which is not a feature of yaml or json.
+           Needed since yaml anchors do not substitute within strings.
+        """
+        if not subs:
+            subs = TildeSubs()
+        if isinstance(obj, (int, float, bool, str)):
+            return
+        if isinstance(obj, Sequence):
+            i = 0
+            for v in obj:
+                self.walk_tilde(v, subs=subs, debug=debug)
+                if isinstance(v, str):
+                    changed = True
+                    newval = v
+                    while changed:
+                        (changed, newval) = subs.expand_val(newval, debug)
+                    if newval != v:
+                        obj[i] = newval
+                i += 1
+        if isinstance(obj, Mapping):
+            subs.push(obj)
+            for (key, value) in obj.items():
+                self.walk_tilde(value, subs=subs, debug=debug)
+            changed = True
+            while changed:
+                changed = False
+                for (key, value) in obj.items():
+                    if isinstance(value, str):
+                        changed = changed or subs.expand_key(key, debug)
+            subs.pop()
 
     def walk(self, obj, path=''):
         if isinstance(obj, Mapping):
@@ -295,6 +397,10 @@ class Cluster(object):
         self.client = client
         self.name = name
         self.cluster_config = cluster_config
+        # keep a config copy until we are sure we don't need unsubst round-trip
+        self.cluster_config_raw = copy.deepcopy(cluster_config)
+        # expand ~{} substitutions
+        self.walk_tilde(self.cluster_config)
         self.endpoints = self.build_endpoints(cluster_config)
         self.aggregators = self.build_aggregators(cluster_config)
         self.groups = self.build_groups(cluster_config)
@@ -355,8 +461,11 @@ class Cluster(object):
         for key in cfg_obj:
             if key != 'interval':
                 if len(cfg_str) > 8:
-                    cfg_str += ' '
-                cfg_str += key + '=' + str(cfg_obj[key])
+                    cfg_str += ' \\\n\t'
+                if str(cfg_obj[key]).lower() == ".keyword":
+                    cfg_str += key
+                else:
+                    cfg_str += key + '=' + str(cfg_obj[key])
         return cfg_str
 
     def config_v4(self, path):
@@ -378,7 +487,7 @@ class Cluster(object):
                             for plugin in self.plugins[group_name]:
                                 cfg_str = self.parse_to_cfg_str(self.plugins[group_name][plugin]['config'])
                                 fd.write(f'load name={plugin}\n')
-                                fd.write(f'config name={plugin} {cfg_str}\n\n')
+                                fd.write(f'config name={plugin} \\\n{cfg_str}\n\n')
 
                     for smplr_group in self.samplers:
                         # TO DO: Refactor sampler config architecture to more easily reference appropriate groups
@@ -390,13 +499,12 @@ class Cluster(object):
                             interval = cvt_intrvl_str_to_us(sampler['interval'].split(':')[0])
                             offset = cvt_intrvl_str_to_us(sampler['interval'].split(':')[1])
                             fd.write(f'load name={sname}\n')
-                            fd.write(f'config {cfg_str} producer=${{HOSTNAME}} '+
-                                     f'component_id=${{COMPONENT_ID}} '+
-                                     f'instance=${{HOSTNAME}}/{sname}\n')
+                            fd.write(f'config {cfg_str}\n')
                             fd.write(f'start name={sname} interval={interval} offset={offset}\n')
                     fd.close()
                 except Exception as e:
                     a, b, d = sys.exc_info()
+                    traceback.print_exc()
                     print(f'Error generating sampler configuration: {str(e)} {str(d.tb_lineno)}')
                     return errno.EINVAL
             else:


### PR DESCRIPTION
This improvement is compatible with existing json, yaml, and env
conventions. Hard-coded defaults which do not support all sampler use
cases are removed from the samplers conf. Samplers which require
ldms keywords (instead of attribute:value) options are now supported
by listing the keyword in the yaml as "'particular_keyword' : .keyword".
When converting to AVL kw & av list, the special value '.keyword'
causes the key/val pair to be treated as an ldms keyword parameter.
In addition, the format of sampler configuration is prettified so humans
can easily understand what is generated.

How the substitution works:
String values in dicts and lists containing ~{key} are expanded with
values of keys at the same or higher dict scope (narrowest dict scope wins
in event of tie). Combined with the yaml anchor syntax, this allows for very DRY
definition of samplers. The example of input is added in config/prod.yaml.