### PR TITLE
Add string validation for cvt_intrvl_str_to_us

### DIFF
--- a/maestro_ctrl
+++ b/maestro_ctrl
@@ -114,11 +114,14 @@ class Cluster(object):
             return groups
         group_conf = config['groups']
         for group_spec in group_conf:
-            self.check_required(['name', 'endpoints', 'interfaces'],
+            self.check_required(['name', 'endpoints'],
                                 group_spec, "daemon specification")
             endpoints = expand_names(group_spec['endpoints'])
             group_name = group_spec['name']
-            interfaces = group_spec['interfaces']
+            if 'interfaces' in group_spec:
+                interfaces = expand_names(group_spec['interfaces'])
+            else:
+                interfaces= []
             group = {
                 'name'       : group_name,
                 'endpoints'  : endpoints,
@@ -161,6 +164,8 @@ class Cluster(object):
         entry is a list of producers in that group.
         """
         producers = {}
+        if 'producers' not in config:
+            return producers
         prod_spec = config['producers']
         for prod in prod_spec:
             self.check_required([ 'names', 'endpoints', 'updaters',
@@ -205,6 +210,8 @@ class Cluster(object):
         entry is a list of updaters in that group.
         """
         updaters = {}
+        if 'updaters' not in config:
+            return updaters
         for updtr_spec in config['updaters']:
             self.check_required([ 'name', 'group', 'interval', 'sets', 'producers' ],
                                 updtr_spec, '"updater" entry')
@@ -318,24 +325,6 @@ class Cluster(object):
         else:
             self.plugins = None
 
-    def cvt_time_spec_to_us(self, ts):
-        if type(ts) == int:
-            return ts * 1000000
-        x = ts.find('us')
-        if x > 0:
-            return ts[:x]
-
-        x = ts.find('ms')
-        if x > 0:
-            return int(float(ts[:x]) * 1000)
-
-        x = ts.find('s')
-        if x > 0:
-            return int(float(ts[:x]) * 1000000)
-
-        # assume seconds
-        return int(float(ts) * 1000000)
-
     def commit(self):
         pass
 
@@ -380,9 +369,10 @@ class Cluster(object):
             # Sampler config
             if self.samplers != None:
                 try:
-                    fd = open(f'{path}/{group_name}-samplers.conf', 'w+')
+                    fd = None
                     if self.plugins != None:
                         if group_name in self.plugins:
+                            fd = open(f'{path}/{group_name}-samplers.conf', 'w+')
                             for plugin in self.plugins[group_name]:
                                 cfg_str = self.parse_to_cfg_str(self.plugins[group_name][plugin]['config'])
                                 fd.write(f'load name={plugin}\n')
@@ -392,6 +382,8 @@ class Cluster(object):
                         # TO DO: Refactor sampler config architecture to more easily reference appropriate groups
                         if group_name != self.samplers[smplr_group]['group']:
                             continue
+                        if fd is None:
+                            fd = open(f'{path}/{group_name}-samplers.conf', 'w+')
                         for sampler in self.samplers[smplr_group]['config']:
                             cfg_str = self.parse_to_cfg_str(sampler)
                             sname = sampler['name']
@@ -405,7 +397,8 @@ class Cluster(object):
                                 fd.write(f'start name={sname} interval={interval} offset={offset}\n')
                             else:
                                 fd.write(f'start name={sname} interval={interval}\n')
-                    fd.close()
+                    if fd:
+                        fd.close()
                 except Exception as e:
                     a, b, d = sys.exc_info()
                     print(f'Error generating sampler configuration: {str(e)} {str(d.tb_lineno)}')
@@ -442,7 +435,7 @@ class Cluster(object):
                             xprt = self.endpoints[producer['endpoint']]['xprt']
                             hostname = self.endpoints[producer['endpoint']]['addr']
                             ptype = producer['type']
-                            interval = cvt_intrvl_str_to_us(producer['reconnect'])
+                            interval = producer['reconnect']
                             fd.write(f'prdcr_add name={pname} '+
                                      f'host={hostname} '+
                                      f'port={port} '+
@@ -530,19 +523,37 @@ def cvt_intrvl_str_to_us(interval_s):
     '1.5S' - 1.5 seconds
     '2s'   - 2 seconds
     """
+    error_str = f"{interval_s} is not a valid time-interval string\n"\
+                f"'Only a single unit-string is allowed. e.g. '50s40us' is not a valid entry."\
+                f"Examples of acceptable format:\n"\
+                f"'1.5s' - 1.5 seconds\n"\
+                f"'1.5S' - 1.5 seconds\n"\
+                f"'2us'  - 2 microseconds\n"\
+                f"'3m'   - 3 minutes\n"\
+                f"\n"
+    if type(interval_s) != str:
+        raise ValueError(f"{error_str}")
     interval_s = interval_s.lower()
     if 'us' in interval_s:
         factor = 1
-        ival_s = interval_s.replace('us','')
+        if interval_s.split('us')[1] != '':
+            raise ValueError(f"{error_str}")
+        ival_s = interval_s.split('us')[0]
     if 'ms' in interval_s:
         factor = 1000
-        ival_s = interval_s.replace('ms','')
+        if interval_s.split('ms')[1] != '':
+            raise ValueError(f"{error_str}")
+        ival_s = interval_s.split('ms')[0]
     elif 's' in interval_s:
         factor = 1000000
-        ival_s = interval_s.replace('s','')
+        if interval_s.split('s')[1] != '':
+            raise ValueError(f"{error_str}")
+        ival_s = interval_s.split('s')[0]
     elif 'm' in interval_s:
         factor = 60000000
-        ival_s = interval_s.replace('m','')
+        if interval_s.split('m')[1] != '':
+            raise ValueError(f"{error_str}")
+        ival_s = interval_s.split('m')[0]
     try:
         mult = float(ival_s)
     except:


### PR DESCRIPTION
Remove deprecated function 'cvt_time_spec_to_us'
Make 'producers' and 'updaters' optional in the ldms configuration yaml
Make 'interfaces' optional in the 'groups' section
Remove bug that can create empty <group_name>-samplers.conf file when generating config files