### PR TITLE
adjust store config output to avoid crash for missing 'flush' parameter

### DIFF
--- a/maestro_ctrl
+++ b/maestro_ctrl
@@ -495,8 +495,11 @@ class Cluster(object):
                                 loaded_plugins.append(store_group[store]["plugin"]["name"])
                             fd.write(f'strgp_add name={store} plugin={store_group[store]["plugin"]["name"]} '+
                                      f'container={store_group[store]["container"]} '+
-                                     f'schema={store_group[store]["schema"]} '+
-                                     f'flush={store_group[store]["flush"]}\n')
+                                     f'schema={store_group[store]["schema"]}')
+                            if "flush" in store_group[store]:
+                                fd.write(f'flush={store_group[store]["flush"]}')
+                            fd.write(f'\n')
+
                             fd.write(f'strgp_start name={store}\n')
             except Exception as e:
                 ea, eb, ec = sys.exc_info()


### PR DESCRIPTION
not all stores have a flush parameter, so it should only be output
when it is defined in the yaml input.