### PR TITLE
add 'maestro_ctrl' label to the exception trap to avoid user confusion

### DIFF
--- a/maestro_ctrl
+++ b/maestro_ctrl
@@ -495,7 +495,7 @@ class Cluster(object):
                             fd.write(f'strgp_start name={store}\n')
             except Exception as e:
                 ea, eb, ec = sys.exc_info()
-                print('Agg config Error: '+str(e)+' Line:'+str(ec.tb_lineno))
+                print('Agg config Error: '+str(e)+'maestro_ctrl Line:'+str(ec.tb_lineno))
 
 def expand_names(name_spec):
     if type(name_spec) != str and isinstance(name_spec, collections.Sequence):


### PR DESCRIPTION
maestro_ctrl prints a line number of its own code rather than the
line number of the offending yaml input. Labeling the "Line xxx"
message as a maestro_ctrl should reduce the time spent by users
trying to find that line number in the input yaml.

It doesn't look like there's an easy way to produce a line reference to the input.