### PR TITLE
add time parse test samplers

### DIFF
--- a/orion-times.yaml
+++ b/orion-times.yaml
@@ -1,0 +1,198 @@
+endpoints:
+  - names : &sampler-endpoints "orion-[01-08]-[10002]"
+    group : samplers
+    hosts : &sampler-hosts "orion-[01-08]"
+    ports : &sampler-ports "[10002]"
+    xprt : sock
+    auth :
+      name   : munge
+      config :
+        domain : samplers
+
+  - names : &l1-agg-endpoints "agg[1-3]"
+    group : &l1-agg "l1-agg"
+    hosts : &agg-host "ovs-5416"
+    ports : "[10101-10103]"
+    xprt : sock
+    auth :
+      name   : munge
+      config :
+        domain : aggregators
+
+  - names : &l2-agg-endpoints "agg-4"
+    group : &l2-agg "l2-agg"
+    hosts : *agg-host
+    ports : "10104"
+    xprt : sock
+    auth :
+      name   : munge
+      config :
+        domain : users
+
+groups:
+  - endpoints : *sampler-endpoints
+    name : samplers
+    interfaces :
+      - *sampler-hosts
+
+  - endpoints : *l1-agg-endpoints
+    name : *l1-agg
+    interfaces :
+      - *sampler-endpoints
+      - *l1-agg-endpoints
+      - *l2-agg-endpoints
+
+  - endpoints : *l2-agg-endpoints
+    name : *l2-agg
+    interfaces :
+      - *l1-agg-endpoints
+      - *l2-agg-endpoints
+
+aggregators:
+  - names     : *l1-agg-endpoints
+    endpoints : *l1-agg-endpoints
+    group     : *l1-agg
+
+  - names     : *l2-agg-endpoints
+    endpoints : *l2-agg-endpoints
+    group     : *l2-agg
+
+producers:
+# This informs the L1 load balance group what is being distributed across
+# the L1 aggregator nodes
+  - names     : *sampler-endpoints
+    endpoints : *sampler-endpoints
+    group     : *l1-agg
+    reconnect : 20s
+    type      : active
+    updaters  :
+      - l1-all
+
+  - names     : *l1-agg-endpoints
+    endpoints : *l1-agg-endpoints
+    group     : *l2-agg
+    reconnect : 20s
+    type      : active
+    updaters  :
+      - l2-all
+
+samplers:
+  - names  : *sampler-endpoints
+    group  : samplers
+    config :
+      - name        : meminfo # Variables can be specific to plugin
+        interval    : "1.0s" # Used when starting the sampler plugin
+        offset      : "0ms"
+        perm        : "0777"
+
+      - name        : vmstat
+        interval    : "1.0s"
+        offset      : "0ms"
+        perm        : "0777"
+
+      - name        : procstat
+        interval    : "1.0s"
+        offset      : "0ms"
+        perm        : "0777"
+
+      - name        : procstat1a
+        interval    : "1ms"
+        offset      : "1ms"
+        perm        : "0777"
+
+      - name        : procstat2a
+        interval    : "1m"
+        offset      : "1m"
+        perm        : "0777"
+
+      - name        : procstat3a
+        interval    : "1s"
+        offset      : "1s"
+        perm        : "0777"
+
+      - name        : procstat4a
+        interval    : "1us"
+        offset      : "1us"
+        perm        : "0777"
+
+      - name        : procstat1
+        interval    : 1ms
+        offset      : 1ms
+        perm        : "0777"
+
+      - name        : procstat2
+        interval    : 1m
+        offset      : 1m
+        perm        : "0777"
+
+      - name        : procstat3
+        interval    : 1s
+        offset      : 1s
+        perm        : "0777"
+
+      - name        : procstat4
+        interval    : 1us
+        offset      : 1us
+        perm        : "0777"
+
+updaters:            
+- name     : all           # must be unique within group
+  group    : *l1-agg
+  interval : "1.0s"
+  offset   : "0ms"
+  sets     :
+    - regex : .*        # regular expression matching set name or schema
+      field : inst      # 'instance' or 'schema'
+  producers :
+    - regex : .*        # regular expression matching producer name
+                        # this is evaluated on the Aggregator, not
+                        # at configuration time'
+- name     : all           # must be unique within group
+  group    : *l2-agg
+  interval : "1.0s"
+  offset   : "0ms"
+  sets     :
+    - regex : meminfo        # regular expression matching set name or schema
+      field : inst      # 'instance' or 'schema'
+  producers :
+    - regex : .*
+
+stores :
+  - name      : sos-meminfo
+    group     : *l2-agg
+    container : ldms_data
+    schema    : meminfo
+    plugin :
+      name   : store_sos
+      config : { path            : /DATA15/orion,
+                 commit_interval : 600
+      }
+
+  - name      : sos-vmstat
+    group     : *l2-agg
+    container : ldms_data
+    schema    : vmstat
+    plugin :
+      name   : store_sos
+      config : { path : /DATA15/orion }
+
+  - name      : sos-procstat
+    group     : *l2-agg
+    container : ldms_data
+    schema    : procstat
+    plugin :
+      name   : store_sos
+      config : { path : /DATA15/orion }
+
+  - name : csv
+    group     : *l2-agg
+    container : ldms_data
+    schema    : meminfo
+    plugin    :
+      name   : store_csv
+      config :
+        path       : /DATA15/orion/csv/orion
+        altheader  : 0
+        typeheader : 1
+        create_uid : 3031
+        create_gid : 3031


### PR DESCRIPTION
python3 yaml does some odd things with time strings for interval/offset/reconnect. This file adds sampler configs with demonstrators of the problem.