### PR TITLE
Add ~{var} expansion in yaml

### DIFF
--- a/maestro_ctrl
+++ b/maestro_ctrl
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#! /usr/bin/env python3
 import os, sys
 import errno
 import yaml
@@ -6,6 +6,7 @@ import argparse
 import etcd3
 import json
 import time
+import copy
 from collections import Mapping, Sequence
 from maestro_util import *
 
@@ -15,6 +16,55 @@ class Cluster(object):
             res = client.put(path, str(value))
         except Exception as e:
             print("Error {0} setting {1} : {2}".format(str(e), path, str(value)))
+
+    def walk_tilde(self, obj, subs=None, debug=False, depth=0):
+        """Walk the obj given and apply ~{} string replacement in place.
+           In scalar values, ~{var} is replaced by its value if
+           var is the name of scalar value at the same or higher scope.
+           This provides us the ability to say:
+           cluster: foo
+             plugins:
+               - name: bar
+                 instance: ~{cluster}/${HOSTNAME}/~{name}
+           which is not a feature of yaml or json.
+           Needed since yaml anchors do not substitute within strings
+           or substitute in a nearest nested scope sense.
+        """
+        if not subs:
+            subs = TildeSubs()
+            subs.expand_anchor(obj, {}, debug)
+        debug = False
+        if isinstance(obj, (int, float, bool, str)):
+            if debug:
+                print(obj)
+            return
+        if isinstance(obj, Sequence):
+            i = 0
+            for v in obj:
+                if debug:
+                    print("depth {}: list[{}]".format(depth, i))
+                self.walk_tilde(v, subs=subs, debug=debug, depth=depth+1)
+                if isinstance(v, str):
+                    changed = True
+                    newval = v
+                    while changed:
+                        (changed, newval) = subs.expand_val(newval, debug)
+                    if newval != v:
+                        obj[i] = newval
+                i += 1
+        if isinstance(obj, Mapping):
+            subs.push(obj)
+            for (key, value) in obj.items():
+                if debug:
+                    print("depth {}: map[{}]".format(depth, key))
+                self.walk_tilde(value, subs=subs, debug=debug, depth=depth+1)
+            changed = True
+            while changed:
+                changed = False
+                for (key, value) in obj.items():
+                    if isinstance(value, str):
+                        changed = changed or subs.expand_key(key, debug)
+            subs.pop()
 
     def check_key(self, key):
         # Handle forward slash in keys e.g. endpoints containing "/" in the name
@@ -341,13 +391,17 @@ class Cluster(object):
         self.client = client
         self.name = name
         self.cluster_config = cluster_config
-        self.daemons = self.build_daemons(cluster_config)
-        self.aggregators = self.build_aggregators(cluster_config)
-        self.producers = self.build_producers(cluster_config)
-        self.updaters = self.build_updaters(cluster_config)
-        self.stores = self.build_stores(cluster_config)
-        self.samplers = self.build_samplers(cluster_config)
-        self.plugins = self.build_plugins(cluster_config)
+        # keep a config copy in case we want an unsubst round-trip
+        self.cluster_config_raw = copy.deepcopy(cluster_config)
+        # tilde-expand self.cluster_config in place
+        self.walk_tilde(self.cluster_config, debug=False)
+        self.daemons = self.build_daemons(self.cluster_config)
+        self.aggregators = self.build_aggregators(self.cluster_config)
+        self.producers = self.build_producers(self.cluster_config)
+        self.updaters = self.build_updaters(self.cluster_config)
+        self.stores = self.build_stores(self.cluster_config)
+        self.samplers = self.build_samplers(self.cluster_config)
+        self.plugins = self.build_plugins(self.cluster_config)
 
     def commit(self):
         pass


### PR DESCRIPTION
After the discussion of supporting ~{} directly in ldms (which
identified the lack of resolution of variables beyond the same
statement as a problem), this patch provides the capability via
tilde-expansion to write most ldms plugin specifications as only two
lines while allowing override for special cases. This patch also lets
us get all the hard-wired yet incorrect (in specific plugin cases) default plugin
settings out of the python layer.

Example:
we can specify most sampler plugins as:
```
    plugins :
      - <<: *sampler-all-defaults
        name : tx2mon
      - <<: *sampler-all-defaults
        name : lustre_client
      - <<: *sampler-all-defaults
        name : loadavg
```
while supporting special cases:
```
     - <<: *sampler-time-defaults
        name : procstat
        config :
          <<: *sampler-config-defaults
          maxcpu : 0
          schema : procstat_0
      - <<: *sampler-time-defaults
        name : sysclassib
        config :
          <<: *sampler-config-defaults
          ports : "mlx5_0.1,mlx5_1.1"
          schema : sysclassib_lserver
      - <<: *sampler-time-defaults
        name : dstat
        config :
          <<: *sampler-config-defaults
          io : 1
          stat : 1
          statm : 1
          fdtypes : 1
          auto-schema : 1
```
if we define defaults as:
```
sampler_time_defaults : &sampler-time-defaults
  interval : "1s"
  offset : "0s"

sampler_all_defaults : &sampler-all-defaults
  <<: *sampler-time-defaults
  config : &sampler-config-defaults
    job_set : ${host}/jobid
    component_id: ${COMPONENT_ID}
    schema : ~{name}
    instance : ${host}/~{schema}
    producer : ${host}
    perm : "0644"
```
Similarly for stores:
```
stores:
  - <<: *csv-defaults
    schema : jobid
  - <<: *csv-defaults
    schema : lustre_client
  - <<: *csv-defaults
    schema : loadavg
  - <<: *csv-defaults
    schema : tx2mon
  - <<: *csv-defaults
    schema : meminfo
```
with special cases:
```
  - <<: *csv-defaults
    schema : meminfo_l1
    metrics:
      - Active
      - MemFree

  - <<: *csv-defaults
    schema : dstat_37
    producers:
      - regex : "wp1.*"
      - regex : "wp2.*"
```
if we define store defaults:
```
store_config_defaults: &csv-defaults
  name : csv-~{schema}
  daemons : *agg-name
  container : store_csv
  plugin :
    name : store_csv
    config :
      path : /ldmslocal/store
      altheader : 0
      typeheader : 1
      create_uid : 3031
      create_gid : 3031
```