### PR TITLE
ldms v4 configuration generation

### DIFF
--- a/Communicator.py
+++ b/Communicator.py
@@ -134,17 +134,6 @@ class Communicator(object):
     def getPort(self):
         return self.port
 
-    def args_to_cfg_str(self, **args):
-        """Convert python arguments to ldmsd readable string"""
-        cfg_str = ''
-        for key in args:
-            if args[key] is None:
-                continue
-            if len(cfg_str):
-                cfg_str += ' '
-            cfg_str += key + '=' + str(args[key])
-        return cfg_str
-
     def send_command(self, cmd):
         """This is called by the LDMSRequest class to send a message"""
         if self.state != self.CONNECTED:
@@ -250,7 +239,7 @@ class Communicator(object):
         except Exception:
             return errno.ENOTCONN, None
 
-    def plugn_config(self, name, **args):
+    def plugn_config(self, name, cfg_str):
         """
         Configure an LDMSD plugin
 
@@ -260,11 +249,6 @@ class Communicator(object):
         Keyword Parameters:
         - dictionary of plugin specific key/value pairs
         """
-        cfg_str = ''
-        for key in args:
-            if len(cfg_str):
-                cfg_str += ' '
-            cfg_str += key + '=' + args[key]
         req = LDMSD_Request(
                 command_id=LDMSD_Request.PLUGN_CONFIG,
                 attrs=[ LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.NAME, value=name),

--- a/config/new_config.yaml
+++ b/config/new_config.yaml
@@ -41,29 +41,42 @@ aggregators:
             sets     :
               - regex : .*
                 field : inst
+    subscribe : # Aggregator stream subscriptions
+      - stream : kokkos-perf-data # Stream name
+        regex : .* # Regular expression that matches producer names
+    plugins   :
+      - name   : kokkos_appmon_store
+        config : { path : /storage/eclipse/sos/ldms-data, stream : kokkos-perf-data }
 
 samplers:
   - daemons : *samplers
-    plugins  :
+    plugins :
       - name        : meminfo # Variables can be specific to plugin
         interval    : 1.0s # Used when starting the sampler plugin
         offset      : "0s"
         config :
             schema : meminfo
+            component_id : "${LDMS_COMPONENT_ID}"
+            producer : "${HOSTNAME}"
+            instance : "${HOSTNAME}/meminfo-test" # If not defined <prdcr_name>/<plugin name> will be used
             perm : "0777"
 
       - name        : vmstat
-        interval    : "1.0s"
-        offset      : "2ms"
+        interval    : "2.0s"
+        offset      : "1ms"
         config :
             schema : vmstat
+            component_id : "${LDMS_COMPONENT_ID}"
+            producer : "${HOSTNAME}"
             perm  : "0777"
 
       - name        : procstat
-        interval    : 3000ms
-        offset      : 1000000us
-        config : 
+        interval    : "4.0s"
+        offset      : 2ms
+        config :
             schema : procstat
+            component_id : "${LDMS_COMPONENT_ID}"
+            producer : "${HOSTNAME}"
             perm : "0777"
 
 stores:

--- a/maestro
+++ b/maestro
@@ -69,13 +69,13 @@ class MaestroMonitor(object):
             self.stores = {}
 
     def set_aggs(self):
-        self.aggregators = {}
         if 'aggregators' in self.config[self.prefix]:
-            for group in self.config[self.prefix]['aggregators']:
-                self.aggregators[group] = {}
-                for agg in self.config[self.prefix]['aggregators'][group]:
-                    self.aggregators[group][agg['name']] = agg
-                    self.aggregators[group][agg['name']]['prdcrs'] = {}
+            self.aggregators = self.config[self.prefix]['aggregators']
+            for group in self.aggregators:
+                for agg in self.aggregators[group]:
+                    self.aggregators[group][agg]['prdcrs'] = {}
+        else:
+            self.aggregators = {}
 
     def set_samplers(self):
         if 'samplers' in self.config[self.prefix]:
@@ -425,18 +425,18 @@ def config_samplers(comms, samplers, daemons):
                 elif err != 0:
                     print(f'Error {err} loading plugin {plugin["name"]}')
                     continue
-                # Auto set producer_name/instance_name first,
+                # Auto set producer_name/instance/component_id to default,
                 # then overwrite if specfied in config
-                cfg_args = { "producer"  : smplr,
-                             "instance"  : smplr +'/'+plugin['name'] }
+                cfg_args = { 'producer'     : smplr,
+                             'instance'     : smplr +'/'+plugin['name'],
+                             'component_id' : '${LDMS_COMPONENT_ID}' }
                 for attr in plugin['config']:
                     if attr == 'name' or attr == 'interval':
                         continue
                     cfg_args[attr] = plugin['config'][attr]
                 # Set component_id to default env variable if not specified
-                if 'component_id' not in plugin['config']:
-                    plugin['config']['component_id'] = '${LDMS_COMPONENT_ID}'
-                err, msg = comm.plugn_config(name=plugin['name'], **cfg_args)
+                cfg_str = parse_to_cfg_str(cfg_args)
+                err, msg = comm.plugn_config(plugin['name'], cfg_str)
                 if err:
                     print(f'Error: {err} {msg} configuring {smplr}')
                     continue
@@ -568,6 +568,16 @@ def add_producers(comms, producers, aggregators, endpoints, agg_state):
                 auth_opt = check_opt('conf', endpoints[dmn_grp][dmn]['endpoints'][ep])
                 plugin = check_opt('plugin', endpoints[dmn_grp][dmn]['endpoints'][ep]['auth'])
 
+            subscribe = check_opt('subscribe', aggregators[grp_name][agg_name])
+            if subscribe is not None:
+                for stream in subscribe:
+                    if 'regex' in stream:
+                        regex = stream['regex']
+                    else:
+                        regex = '.*'
+                    rc, err = comm.prdcr_subscribe(stream=stream['stream'], regex=regex)
+                    if rc:
+                        print(f'Error {rc} subscribing to stream {stream["stream"]}: {err}.')
             if auth is not None:
                 rc, msg = comm.auth_add(auth, plugin, auth_opt)
                 if rc:
@@ -586,13 +596,6 @@ def add_producers(comms, producers, aggregators, endpoints, agg_state):
                             prod_name, prod['type'],
                             endpoint['xprt'], endpoint['addr'], endpoint['port'],
                             prod['reconnect'], auth=auth)
-                if 'subscribe' in prod:
-                    for sub in prod['subscribe']:
-                        if 'regex' in sub:
-                            regex = sub['regex']
-                        else:
-                            regex = '.*'
-                        comm.prdcr_subscribe(stream=sub['stream'], regex=regex)
     return True
 
 def add_updaters(comms, updaters, aggregators, daemons, agg_state, rb=None):
@@ -669,9 +672,9 @@ def add_stores(comms, stores, aggregators, daemons, agg_state):
                 # Load and configure the plugin required by the store
                 plugin = store['plugin']
                 plugin_name = plugin['name']
-                plugin_config = plugin['config']
+                cfg_str = parse_to_cfg_str(plugin['config'])
                 err, res = comm.plugn_load(plugin_name)
-                err, res = comm.plugn_config(plugin_name, **plugin_config)
+                err, res = comm.plugn_config(plugin_name, cfg_str)
                 flush = check_opt('flush', store)
                 ## the stores may already exist, in which case the add will fail
                 err, res = comm.strgp_add(store_name,

--- a/maestro_ctrl
+++ b/maestro_ctrl
@@ -157,25 +157,22 @@ class Cluster(object):
                            agg_spec, "aggregator specification")
             names = expand_names(agg_spec['daemons'])
             group = agg_spec['daemons']
-            endpoints = []
+            plugins = check_opt('plugins', agg_spec)
             daemons_ = None
             for daemons in config['daemons']:
                 if group == daemons['names']:
                     daemons_ = daemons
             if daemons_ is None:
                 raise ValueError(f"No daemons matched matched daemon key {group}")
-            for eps in daemons_['endpoints']:
-                if eps['maestro_comm'] is True:
-                    endpoints += expand_names(eps['names'])
             if group not in aggregators:
-                aggregators[group] = []
+                aggregators[group] = {}
+            subscribe = check_opt('subscribe', agg_spec)
             for name in names:
-                endpoint = endpoints.pop(0)
-                agg = {
-                        'name'      : name,
-                        'state'     : 'stopped' # 'running', 'error'
-                }
-                aggregators[group].append(agg)
+                aggregators[group][name] = { 'state' : 'stopped' } # 'running', 'error'
+                if subscribe:
+                    aggregators[group][name]['subscribe'] = subscribe
+                if plugins:
+                    aggregators[group][name]['plugins'] = plugins
         return aggregators
 
     def build_producers(self, config):
@@ -200,7 +197,6 @@ class Cluster(object):
                 if group not in producers:
                     producers[group] = {}
 
-                subscribe = check_opt('subscribe', prod)
                 if len(names) != len(endpoints):
                     raise ValueError('"producer": The "host" and "name" specifications must '
                                      '            expand to the same number of strings')
@@ -221,8 +217,6 @@ class Cluster(object):
                         'reconnect' : reconnect,
                         'updaters'  : upd_spec
                     }
-                    if subscribe:
-                        prod['subscribe'] = subscribe
                     producers[group][endpoint] = prod
         return producers
 
@@ -377,9 +371,10 @@ class Cluster(object):
                     auth = check_opt('auth', ep)
                     auth_opt = check_opt('conf', ep)
                     if auth:
-                        fd.write(f'auth_add')
-                        self.write_opt_attr(fd, 'name', auth, endline=False)
-                        self.write_opt_attr(fd, 'conf', auth_opt, endline=True)
+                        plugin = check_opt('plugin', ep['auth'])
+                        fd.write(f'auth_add name={auth}')
+                        self.write_opt_attr(fd, 'plugin', plugin, endline=False)
+                        self.write_opt_attr(fd, 'conf', auth_opt)
                     fd.write(f'listen xprt={ep["xprt"]} port={ep["port"]}')
                     self.write_opt_attr(fd, 'auth', auth, endline=False)
                     self.write_opt_attr(fd, 'conf', auth_opt)
@@ -397,7 +392,7 @@ class Cluster(object):
         if group_name in self.producers:
             ''' Balance samplers across aggregators '''
             prdcrs = []
-            loop = round(len(self.producers[group_name]) / len(self.aggregators[group_name]))
+            loop = round(len(self.producers[group_name]) / len(self.aggregators[group_name].keys()))
             last_sampler = None
             for prdcr in self.producers[group_name]:
                 prdcrs.append(prdcr)
@@ -418,7 +413,12 @@ class Cluster(object):
                 else:
                     auths[auth] = { 'conf' : auth_opt }
             for auth in auths:
-                fd.write(f'auth_add name={auth}')
+                plugin = check_opt('plugin', self.daemons[producer['dmn_grp']][producer['daemon']]['endpoints'][ep]['auth'])
+                if plugin is None:
+                    print(f'Please specify auth plugin type for producer "{producer["daemon"]}" with auth name "{auth}"\n'\
+                           'configuration file generation will continue, but auth will likely be denied.\n')
+                    plugin = auth
+                fd.write(f'auth_add name={auth} plugin={plugin}')
                 self.write_opt_attr(fd, 'conf', auths[auth]['conf'])
             for ep in prod_group:
                 if i >= loop:
@@ -429,12 +429,16 @@ class Cluster(object):
                 port = self.daemons[producer['dmn_grp']][producer['daemon']]['endpoints'][ep]['port']
                 xprt = self.daemons[producer['dmn_grp']][producer['daemon']]['endpoints'][ep]['xprt']
                 hostname = self.daemons[producer['dmn_grp']][producer['daemon']]['endpoints'][ep]['addr']
+                auth = check_opt('auth', self.daemons[producer['dmn_grp']][producer['daemon']]['endpoints'][ep])
                 ptype = producer['type']
                 interval = producer['reconnect']
                 fd.write(f'prdcr_add name={pname} '+
                          f'host={hostname} '+
                          f'port={port} '+
-                         f'xprt={xprt} type={ptype} interval={interval}\n')
+                         f'xprt={xprt} '+
+                         f'type={ptype} '+
+                         f'interval={interval}')
+                self.write_opt_attr(fd, 'auth', auth)
                 last_sampler = pname
                 i += 1
                 if 'regex' in producer:
@@ -445,13 +449,19 @@ class Cluster(object):
 
     def write_samplers(self, fd, smplr_group):
         for sampler in self.samplers[smplr_group]['plugins']:
-            cfg_str = parse_to_cfg_str(sampler['config'])
+            cfg_args = { 'producer'     : '${HOSTNAME}',
+                         'instance'     : '${HOSTNAME}' +'/'+sampler['name'],
+                         'component_id' : '${LDMS_COMPONENT_ID}' }
+            for attr in sampler['config']:
+                if attr == 'name' or attr == 'interval':
+                    continue
+                cfg_args[attr] = sampler['config'][attr]
+
             sname = sampler['name']
+            cfg_str = parse_to_cfg_str(cfg_args)
             interval = cvt_intrvl_str_to_us(sampler['interval'])
             fd.write(f'load name={sname}\n')
-            fd.write(f'config {cfg_str} producer=${{HOSTNAME}} '+
-                     f'component_id=${{COMPONENT_ID}} '+
-                     f'instance=${{HOSTNAME}}/{sname}\n')
+            fd.write(f'config name={sname} {cfg_str}\n')
             fd.write(f'start name={sname} interval={interval}')
             offset = check_opt('offset', sampler)
             self.write_opt_attr(fd, 'offset', offset)
@@ -466,22 +476,24 @@ class Cluster(object):
                     fd.write(f'config name={plugin} {cfg_str}\n\n')
                 fd.close()
 
-    def write_agg_plugins(self, fd, group_name):
+    def write_stream_subscribe(self, fd, group_name, agg):
+        subscribe = check_opt('subscribe', self.aggregators[group_name][agg])
+        if subscribe:
+            for stream in subscribe:
+                regex = check_opt('regex', stream)
+                if 'regex' is None:
+                    regex = '.*'
+                fd.write(f'prdcr_subscribe stream={stream["stream"]} '\
+                         f'regex={regex}\n')
+
+    def write_agg_plugins(self, fd, group_name, agg):
         # Write independent plugin configuration for group <group_name>
-        if self.plugins != None:
-            if group_name in self.plugins:
-                for plugin in self.plugins[group_name]:
-                    cfg_str = parse_to_cfg_str(self.plugins[group_name][plugin]['config'])
-                    if 'stream' in self.plugins[group_name][plugin]['config']:
-                        if 'regex' in self.plugins[group_name][plugin]['config']:
-                            regex = self.plugins[group_name][plugin]['config']
-                            fd.write(f'prdcr_subscribe stream={self.plugins[group_name][plugin]["config"]["stream"]} '\
-                                     f'regex={regex}\n')
-                        else:
-                            fd.write(f'prdcr_subscribe stream={self.plugins[group_name][plugin]["config"]["stream"]} '\
-                                     f'regex=.*\n')
-                    fd.write(f'load name={plugin}\n')
-                    fd.write(f'config name={plugin} {cfg_str}\n\n')
+        plugins = check_opt('plugins', self.aggregators[group_name][agg])
+        if plugins is not None:
+            for plugin in plugins:
+                cfg_str = parse_to_cfg_str(plugin['config'])
+                fd.write(f'load name={plugin["name"]}\n')
+                fd.write(f'config name={plugin["name"]} {cfg_str}\n\n')
 
     def write_updaters(self, fd, group_name):
         if group_name in self.updaters:
@@ -557,10 +569,11 @@ class Cluster(object):
                     continue
                 last_sampler = None
                 for agg in self.aggregators[group_name]:
-                    fd = open(f'{path}/{group_name}-{agg["name"]}.conf', 'w+')
+                    fd = open(f'{path}/{agg}.conf', 'w+')
                     self.write_listeners(fd, group_name)
                     self.write_producers(fd, group_name)
-                    self.write_agg_plugins(fd, group_name)
+                    self.write_stream_subscribe(fd, group_name, agg)
+                    self.write_agg_plugins(fd, group_name, agg)
                     self.write_updaters(fd, group_name)
                     self.write_stores(fd, group_name)
             except Exception as e:


### PR DESCRIPTION
aggregators stored in maestro by agg name as a key, rather than list
support for plugins included in aggregators yaml key
maestro: update plugn_config calls
maestro: parse config string before submitting to plugn_config
maestro + maestro_ctrl: update stream subscribe for ldms yaml config
file
maestro_ctrl: include auth plugin types in prdcr_add
remove deprecated function from Communicator
Communicator: plugn_config now expects a configuration string rather
than a dictionary