### PR TITLE
Fix producers-daemons-endpoints mapping in `maestro_ctrl`

### DIFF
--- a/maestro_ctrl
+++ b/maestro_ctrl
@@ -208,7 +208,7 @@ class Cluster(object):
                 ppd = ports_per_dmn
                 try:
                     for name in names:
-                        if ppd >= 0:
+                        if ppd > 1:
                             smplr_dmn = smplr_dmns[0]
                             ppd -= 1
                         else:


### PR DESCRIPTION
The producers-daemons-endpoints mapping was incorrect in
`maestro_ctl:Cluster.build_producers()` because the `daemon` was not
popped from the `daemons` list when the endpoints corresponding with
daemon exhausted. This patch modifies the daemon pop condition, making
it matches the corresponding endpoints.