### PR TITLE
Add support for sampler only config

### DIFF
--- a/maestro
+++ b/maestro
@@ -56,17 +56,10 @@ class MaestroMonitor(object):
         """
         self.daemons = self.config[self.prefix]['daemons']
         self.set_samplers()
-        if 'producers' in self.config[self.prefix]:
-            self.producers = self.config[self.prefix]['producers']
-        else:
-            self.producers = {}
-        self.producers = self.config[self.prefix]['producers']
+        self.producers = self.config[self.prefix].get('producers', dict())
         self.set_aggs()
-        self.updaters = self.config[self.prefix]['updaters']
-        if 'stores' in self.config[self.prefix]:
-            self.stores = self.config[self.prefix]['stores']
-        else:
-            self.stores = {}
+        self.updaters = self.config[self.prefix].get('updaters', dict())
+        self.stores = self.config[self.prefix].get('stores', dict())
 
     def set_aggs(self):
         if 'aggregators' in self.config[self.prefix]:
@@ -602,10 +595,10 @@ def add_updaters(comms, updaters, aggregators, daemons, agg_state, rb=None):
     """
     Add updaters to Aggregators
     """
+    rc = True
     for grp_name in updaters:
         grp_updaters = updaters[grp_name]
         group = aggregators[grp_name]
-        rc = True
         for updtr_name in grp_updaters:
             updtr = grp_updaters[updtr_name]
             for agg_name, agg_host in agg_hosts(grp_name, aggregators, daemons):

--- a/maestro_ctrl
+++ b/maestro_ctrl
@@ -181,7 +181,7 @@ class Cluster(object):
         entry is a list of producers in that group.
         """
         producers = {}
-        for agg in config['aggregators']:
+        for agg in config.get('aggregators', []):
             if 'peers' not in agg:
                 continue
             for prod in agg['peers']:
@@ -238,7 +238,7 @@ class Cluster(object):
         """
         updaters = {}
         updtr_cnt = 0
-        for agg in config['aggregators']:
+        for agg in config.get('aggregators', []):
             if 'peers' not in agg:
                 continue
             for prod in agg['peers']:


### PR DESCRIPTION
In the LDMS YAML configuration, if the 'producers' or 'updaters' are
not specified, `maestro` will crash with `KeyError`. This patch allows
the absense of 'producers' and 'updaters'.