### PR TITLE
`expand_hostlist()` with number support

### DIFF
--- a/hostlist.py
+++ b/hostlist.py
@@ -69,7 +69,8 @@ def expand_hostlist(hostlist, allow_duplicates=False, sort=False):
     results = []
     bracket_level = 0
     part = ""
-    
+    if type(hostlist) in [int, float]:
+        hostlist = str(hostlist)
     for c in hostlist + ",":
         if c == "," and bracket_level == 0:
             # Comma at top level, split!


### PR DESCRIPTION
`hostlist.py:expand_hostlist()` is not only used to expand hostlist, but
also other values such as ports. In the case of single port, the user
may enter the numeric value instead of string (411 instead of "411").
This patch modifies the function to also accept numbers (integers or
floats) for users' convenience.