### PR TITLE
Bug fix for daemon configuration in yaml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,14 +96,17 @@ daemons:
         maestro_comm : True
         xprt  : sock
         auth  :
-           name : munge
+           name : ovis1 # The authentication domain name
+           plugin : ovis # The plugin type
+           conf : /opt/ovis/maestro/secret.conf
 
       - names : &sampler-rdma-endpoints "node-[1-10]-10002/rdma"
         ports : *sampler-ports
         maestro_comm : False
         xprt  : rdma
         auth  :
-          name : munge
+          name : munge1
+          plugin : munge
 
   - names : &l1-agg "l1-aggs-[11-14]"
     hosts : &l1-agg-hosts "node-[11-14]"
@@ -113,7 +116,8 @@ daemons:
         maestro_comm : True
         xprt  : sock
         auth  :
-          name : munge
+          name : munge1
+          plugin : munge
 
   - names : &l2-agg "l2-agg"
     hosts : &l2-agg-host "node-15"
@@ -123,7 +127,8 @@ daemons:
         maestro_comm : True
         xprt  : sock
         auth  :
-          name : munge
+          name : munge1
+          plugin : munge
 
 aggregators:
   - daemons   : *l1-agg

--- a/config/new_config.yaml
+++ b/config/new_config.yaml
@@ -7,15 +7,17 @@ daemons:
         maestro_comm : True
         xprt  : sock
         auth  :
-           name : ovis
-           conf : /home/nick/projects/old-maestro/secret.conf
+           name : ovis1
+           plugin : ovis
+           conf : /opt/ovis/maestro/secret.conf
 
       - names : &sampler-rdma-endpoints "node-[01-08]-10002/rdma"
         ports : *sampler-ports
         maestro_comm : False
         xprt  : rdma
         auth  :
-          name : munge
+          name : munge1
+          plugin : munge
 
   - names : &l1-agg "l1-aggs-[1-8]"
     hosts : &l1-agg-hosts "node-[01-08]"
@@ -25,7 +27,8 @@ daemons:
         maestro_comm : True
         xprt  : sock
         auth  :
-          name : munge
+          name : munge1
+          plugin : munge
 
 aggregators:
   - daemons   : *l1-agg

--- a/maestro
+++ b/maestro
@@ -84,20 +84,27 @@ class MaestroMonitor(object):
                 listen = []
                 for ep_name in self.daemons[dmn_grp][dmn_name]['endpoints']:
                     ep = self.daemons[dmn_grp][dmn_name]['endpoints'][ep_name]
+                    hostname = self.daemons[dmn_grp][dmn_name]['addr']
                     if 'maestro_comm' not in ep:
                         listen.append(ep)
                         continue
                     conf = check_opt('conf', ep)
-                    comm = Communicator(ep['xprt'],
-                                        ep['addr'],
-                                        ep['port'],
-                                        ep['auth']['name'],
-                                        { 'conf' : conf })
+                    try:
+                        comm = Communicator(ep['xprt'],
+                                            hostname,
+                                            ep['port'],
+                                            ep['auth']['plugin'],
+                                            { 'conf' : conf })
+                    except Exception as e:
+                        print(f'Error initializing transport to ldmsd {dmn_name} at endpoint {ep_name} '\
+                              f'on port {ep["port"]} with transport {ep["xprt"]}')
+                        print(f'{e}')
+                        sys.exit()
                     rc = comm.connect()
                     if not rc:
                         print(f'Failed to communicate with aggregator {dmn_name} on endpoint {ep["name"]}')
                     comms[dmn_grp][dmn_name] = comm
-                add_listeners(comm, dmn_name, listen)
+                    add_listeners(comm, dmn_name, listen)
         return comms
 
     def check_aggs(self, group, agg_state):
@@ -584,10 +591,11 @@ def add_producers(comms, producers, aggregators, endpoints, agg_state):
                 dmn = prod_dict[prod_name]['daemon']
                 ep_name = prod['endpoint']
                 endpoint = endpoints[dmn_grp][dmn]['endpoints'][ep_name]
+                hostname = endpoints[dmn_grp][dmn]['addr']
                 auth = check_opt('auth', endpoint)
                 comm.prdcr_add(
                             prod_name, prod['type'],
-                            endpoint['xprt'], endpoint['addr'], endpoint['port'],
+                            endpoint['xprt'], hostname, endpoint['port'],
                             prod['reconnect'], auth=auth)
     return True
 

--- a/maestro_ctrl
+++ b/maestro_ctrl
@@ -6,6 +6,7 @@ import argparse
 import etcd3
 import json
 import time
+import itertools as it
 from collections import Mapping, Sequence
 from maestro_util import *
 
@@ -92,22 +93,29 @@ class Cluster(object):
                            spec, "daemons specification")
             hosts = expand_names(spec['hosts'])
             dnames = expand_names(spec['names'])
+            hostnames = hosts
+            if len(dnames) != len(hostnames):
+                hosts = [ [host]*(len(dnames)//len(hostnames)) for host in hostnames ]
+                hosts = list(it.chain.from_iterable(hosts))
             ep_names = []
-            ports = []
+            ep_ports = []
             for endpoints in spec['endpoints']:
                 check_required(['names','ports'],
                                endpoints, 'endpoint specification')
-                ep_names.append(expand_names(endpoints['names']))
-                epnames = expand_names(endpoints['names'])
-                ep_ports = expand_names(endpoints['ports'])
-                if len(ep_ports) != len(epnames):
-                    ep_ports += [ ep_ports[0] for i in range(0, len(epnames)) ]
-                ports.append(ep_ports)
+                cur_epnames = expand_names(endpoints['names'])
+                ep_names.append(cur_epnames)
+                cur_ports = expand_names(endpoints['ports'])
+                _ports = cur_ports
+                if len(cur_ports) != len(cur_epnames):
+                    cur_ports = [ _ports for i in range(0, len(cur_epnames)//len(_ports)) ]
+                    cur_ports = list(it.chain.from_iterable(cur_ports))
+                ep_ports.append(cur_ports)
             ep_dict[spec['names']] = {}
             for dname, host in zip(dnames, hosts):
                 ep_dict[spec['names']][dname] = {}
+                ep_dict[spec['names']][dname]['addr'] = host
                 ep_dict[spec['names']][dname]['endpoints'] = {}
-                for ep_, ep_port, ep in zip(ep_names, ports, spec['endpoints']):
+                for ep_, ep_port, ep in zip(ep_names, ep_ports, spec['endpoints']):
                     port = ep_port.pop(0)
                     ep_name = ep_.pop(0)
                     xprt = check_opt('xprt', ep)
@@ -117,7 +125,6 @@ class Cluster(object):
                     maestro_comm = parse_yaml_bool(check_opt('maestro_comm', ep))
                     h = {
                         'name' : ep_name,
-                        'addr' : host,
                         'port' : port,
                         'xprt' : xprt,
                         'maestro_comm' : maestro_comm,
@@ -439,7 +446,7 @@ class Cluster(object):
                 pname = producer['name']
                 port = self.daemons[producer['dmn_grp']][producer['daemon']]['endpoints'][ep]['port']
                 xprt = self.daemons[producer['dmn_grp']][producer['daemon']]['endpoints'][ep]['xprt']
-                hostname = self.daemons[producer['dmn_grp']][producer['daemon']]['endpoints'][ep]['addr']
+                hostname = self.daemons[producer['dmn_grp']][producer['daemon']]['addr']
                 auth = check_opt('auth', self.daemons[producer['dmn_grp']][producer['daemon']]['endpoints'][ep])
                 ptype = producer['type']
                 interval = producer['reconnect']


### PR DESCRIPTION
Fix addresses a single "daemons" key configuration in yaml file when multiple hosts are
specified and multiple daemons exist on each host
Daemon hostname key:value no longer nested in daemons "endpoints" key