### PR TITLE
Bug Fixes for maestro and maestro_util

### DIFF
--- a/maestro
+++ b/maestro
@@ -589,6 +589,7 @@ def add_producers(comms, producers, aggregators, endpoints, agg_state):
                     continue
                 prod = prod_dict[prod_name]
                 dmn = prod_dict[prod_name]['daemon']
+                dmn_grp = prod_dict[prod_name]['dmn_grp']
                 ep_name = prod['endpoint']
                 endpoint = endpoints[dmn_grp][dmn]['endpoints'][ep_name]
                 hostname = endpoints[dmn_grp][dmn]['addr']

--- a/maestro_util.py
+++ b/maestro_util.py
@@ -78,6 +78,9 @@ def cvt_intrvl_str_to_us(interval_s):
         if interval_s.split('m')[1] != '':
             raise ValueError(f"{error_str}")
         ival_s = interval_s.split('m')[0]
+    else:
+        ival_s = interval_s
+        factor = 1
     try:
         mult = float(ival_s)
     except:
@@ -86,6 +89,8 @@ def cvt_intrvl_str_to_us(interval_s):
 
 def check_offset(interval_us, offset_us=None):
     if offset_us:
+        interval_us = int(interval_us)
+        offset_us = int(offset_us)
         if offset_us/interval_us > .5:
             offset_us = interval_us/2
     else:


### PR DESCRIPTION
Fix bug where maestro adds producers to a single aggregator from multiple daemon definitions
cvt_intrvl_str_to_us - fix for numbers with a string type that would not be properly handled (e.g. "5000")
check_offset - ensure both interval_us and offset_us are integers before performing numerical operations