### PR TITLE
Update ldms yaml updater mode definition

### DIFF
--- a/config/new_config.yaml
+++ b/config/new_config.yaml
@@ -37,13 +37,36 @@ aggregators:
         endpoints : *sampler-endpoints
         reconnect : 20s
         type      : active
-        updaters  :
+        updaters  : # The following are possible usages of each updater mode
           - mode     : pull
             interval : "1.0s"
             offset   : "0ms"
             sets     :
               - regex : .*
                 field : inst
+
+          # Examples of other updater modes are listed below
+          #- mode     : auto 
+          #  interval : "1.0s"
+          #  offset   : "0ms"
+          #  sets     :
+          #    - regex : .*
+          #      field : inst
+
+          #- mode     : push
+          #  interval : "1.0s"
+          #  offset   : "0ms"
+          #  sets     :
+          #    - regex : .*
+          #      field : inst
+
+          #- mode     : onchange
+          #  interval : "1.0s"
+          #  offset   : "0ms"
+          #  sets     :
+          #    - regex : .*
+          #      field : inst
+
     subscribe : # Aggregator stream subscriptions
       - stream : kokkos-perf-data # Stream name
         regex : .* # Regular expression that matches producer names

--- a/scripts/maestro
+++ b/scripts/maestro
@@ -681,10 +681,12 @@ def add_updaters(comms, updaters, aggregators, daemons, agg_state, rb=None):
                         rc, err = comm.updtr_del(agg_updtr)
                         if rc:
                             print(f'Error removing updater {agg_updtr}: {err}')
-                if 'push' in updtr:
-                    rc, msg = comm.updtr_add(agg_updtr, interval=updtr['interval'], offset=offset, push=updtr['push'])
-                elif 'auto' in updtr and updtr['auto'] == "True":
-                    rc, msg = comm.updtr_add(agg_updtr, interval=updtr['interval'], offset=offset, auto=updtr['auto'])
+                if updtr['mode'] == 'auto' or updtr['mode'] == 'auto_interval':
+                    rc, msg = comm.updtr_add(agg_updtr, interval=updtr['interval'], offset=offset, auto=True)
+                elif updtr['mode'] == 'push':
+                    rc, msg = comm.updtr_add(agg_updtr, interval=updtr['interval'], offset=offset, push=True)
+                elif updtr['mode'] == 'onchange':
+                    rc, msg = comm.updtr_add(agg_updtr, interval=updtr['interval'], offset=offset, push='onchange')
                 else:
                     rc, msg = comm.updtr_add(agg_updtr, interval=updtr['interval'], offset=offset)
 

--- a/scripts/maestro_ctrl
+++ b/scripts/maestro_ctrl
@@ -271,14 +271,10 @@ class ClusterCtrl(object):
                     }
                     if 'offset' in updtr_spec:
                         updtr['offset'] = cvt_intrvl_str_to_us(updtr_spec['offset'])
-                    if 'auto' in updtr_spec and 'push' in updtr_spec:
-                        raise ValueError(f"The updater specification: {json.dumps(updtr_spec)} "
-                                          "contains both 'push' and 'auto' which are "
-                                          "mutually exclusive")
-                    if 'auto' in updtr_spec:
-                        updtr['auto'] = updtr_spec['auto']
-                    if 'push' in updtr_spec:
-                        updtr['push'] = updtr_spec['push']
+                    if 'mode' in updtr_spec:
+                        updtr['mode'] = updtr_spec['mode']
+                    else:
+                        updtr['mode'] = 'pull'
                     grp_updaters[updtr_name] = updtr
                     updtr_cnt += 1
         return updaters
@@ -665,13 +661,15 @@ class ClusterCtrl(object):
                 if 'mode' in updtr_group[updtr]:
                     mode = updtr_group[updtr]['mode']
                 else:
-                    mode = 'static'
+                    mode = 'pull'
                 # Check mode
                 if mode == 'push':
-                    updtr_str += 'push=onchange\n'
-                elif mode == 'auto_interval':
-                    updtr_str += 'auto_interval=True\n'
-                fd.write(f'updtr_add name={updtr_group[updtr]["name"]} '+
+                    updtr_str = f'{updtr_str} push=True'
+                elif mode == 'onchange':
+                    updtr_str = f'{updtr_str} push=onchange'
+                elif mode == 'auto_interval' or 'auto':
+                    updtr_str = f'{updtr_str} auto_interval=True'
+                fd.write(f'{updtr_str} '+
                          f'interval={interval}')
                 offset = check_opt('offset', updtr_group[updtr])
                 self.write_opt_attr(fd, 'offset', offset)

--- a/src/maestro/Communicator.py
+++ b/src/maestro/Communicator.py
@@ -655,7 +655,7 @@ class Communicator(object):
             status = None
         return err, status
 
-    def updtr_add(self, name, interval=None, offset=None, push=None, auto=None, perm=None):
+    def updtr_add(self, name, interval, offset=None, push=None, auto=None, perm=None):
         """
         Add an Updater that will periodically update Producer metric sets either
         by pulling the content or by registering for an update push. The default
@@ -687,25 +687,23 @@ class Communicator(object):
         - data is an error message if status != 0 or None
         """
         attrs = [
-            LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.NAME, value=name)
+            LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.NAME, value=name),
+            LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.INTERVAL, value=str(interval))
         ]
-        if interval:
-            offset = check_offset(interval, offset)
+        offset = check_offset(interval, offset)
+        if offset:
             attrs += [
-                LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.INTERVAL, value=str(interval)),
                 LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.OFFSET, value=str(offset))
+            ]
+        if auto:
+            attrs += [
+                LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.AUTO_INTERVAL, value=str(auto))
             ]
         elif push:
             if push != 'onchange' and push != True:
                 return errno.EINVAL, "EINVAL"
             attrs += [
                 LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.PUSH, value=str(push))
-            ]
-        else:
-            if auto is None:
-                return errno.EINVAL, "EINVAL"
-            attrs += [
-                LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.AUTO_INTERVAL, value=str(auto))
             ]
         if perm:
             attrs.append(LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.PERM, value=str(perm)))
@@ -797,8 +795,9 @@ class Communicator(object):
                 return errno.EINVAL, "'auto' is incompatible with 'interval'"
             attrs += [
                 LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.INTERVAL, value=str(interval)),
-                LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.OFFSET, value=str(offset))
             ]
+            if offset:
+                attrs.append(LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.OFFSET, value=str(offset)))
         elif auto:
             attrs += [
                 LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.AUTO_INTERVAL, value=str(auto))

--- a/src/maestro/maestro_util.py
+++ b/src/maestro/maestro_util.py
@@ -93,8 +93,6 @@ def check_offset(interval_us, offset_us=None):
         offset_us = int(offset_us)
         if offset_us/interval_us > .5:
             offset_us = interval_us/2
-    else:
-        offset_us = 0
     return offset_us
 
 def check_opt(attr, spec):


### PR DESCRIPTION
mode options are : pull, auto, push, onchange
pull - default, updater will schedule set updates according to defined
interval and offset values
auto - updater will schedule set updates according to update hint
push - updater will receive an update only when the set source
explicitly pushes an update
onchange - updater will get an update whenever the set source ends a
transaction or pushes an update