### PR TITLE
Ubuntu22.04

### DIFF
--- a/scripts/maestro_ctrl
+++ b/scripts/maestro_ctrl
@@ -8,7 +8,7 @@ import subprocess
 import socket
 import time
 import itertools as it
-from collections import Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from maestro.maestro_util import *
 
 class ClusterCtrl(object):

--- a/scripts/maestro_ctrl
+++ b/scripts/maestro_ctrl
@@ -608,7 +608,7 @@ class ClusterCtrl(object):
         if subscribe:
             for stream in subscribe:
                 regex = check_opt('regex', stream)
-                if 'regex' is None:
+                if regex is None:
                     regex = '.*'
                 fd.write(f'prdcr_subscribe stream={stream["stream"]} '\
                          f'regex={regex}\n')

--- a/src/maestro/maestro_util.py
+++ b/src/maestro/maestro_util.py
@@ -126,7 +126,7 @@ def NUM_STR(obj):
     return str(obj) if type(obj) in [ int, float ] else obj
 
 def expand_names(name_spec):
-    if type(name_spec) != str and isinstance(name_spec, collections.Sequence):
+    if type(name_spec) != str and isinstance(name_spec, collections.abc.Sequence):
         names = []
         for name in name_spec:
             names += hostlist.expand_hostlist(NUM_STR(name))


### PR DESCRIPTION
This PR contains 2 patches:

```
    Fix Python3.10 `collections.*` location

    `collections.*` datatypes has been deprecated since Python 3.3, and were
    moved into `collections.abc.*`. The `collections.*` aliases to the
    actual datatypes in `collections.abc.*` were removed in Python 3.10
    (reference: https://docs.python.org/3.9/library/collections.html).

    Ubuntug 22.04 uses Python 3.10, and `maestro_ctrl` because of the
    collections datatypes relocation mentioned above. This patch addressed
    locations in this project that use `collections.*` datatypes.

    NOTE: This has been tested on CentOS7 and Ubuntu 22.04

```

```
    Fix typo in maestro_ctrl
```