### PR TITLE
Schema Registry fetature

### DIFF
--- a/C/.gitignore
+++ b/C/.gitignore
@@ -1,0 +1,2 @@
+*.so
+msr_test

--- a/C/Makefile
+++ b/C/Makefile
@@ -1,0 +1,33 @@
+OVIS_PREFIX ?= /opt/ovis
+
+ifdef OVIS_PREFIX
+	OVIS_INCLUDES = -I$(OVIS_PREFIX)/include
+	OVIS_LIBS = -L$(OVIS_PREFIX)/lib -L$(OVIS_PREFIX)/lib64
+else
+	OVIS_INCLUDES =
+	OVIS_LIBS =
+endif
+
+CFLAGS = -ggdb3 -O0 $(OVIS_INCLUDES)
+LDFLAGS = $(OVIS_LIBS) -lldms -lcurl -ljansson
+
+all: libmsr_client.so msr_test
+
+libmsr_client_so_SOURCES = msr_client.c
+
+libmsr_client.so: $(libmsr_client_so_SOURCES) Makefile
+	$(CC) $(libmsr_client_so_SOURCES) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -shared -o $@
+
+msr_test: msr_test.c libmsr_client.so Makefile
+	$(CC) $< $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -L. -lmsr_client -o $@
+
+clean:
+	rm -f libmsr_client.so msr_test
+
+
+install: libmsr_client.so msr_client.h msr_test
+	LIBPREFIX=$$(ldd libmsr_client.so | grep libldms.so | \
+		  		sed 's/.* => \(\S\+\)\/libldms.so.*/\1/' \
+			); \
+	install -t $${LIBPREFIX}/ libmsr_client.so ; \
+	install -t $${LIBPREFIX}/../bin msr_test

--- a/C/ldms_schema_access.c
+++ b/C/ldms_schema_access.c
@@ -1,0 +1,103 @@
+#include <openssl/evp.h>
+
+#include "ldms_schema_access.h"
+#include "ldms/ldms.h"
+
+struct ldms_mdef_s {
+	char *name;
+	char *unit;
+	enum ldms_value_type type;
+	uint32_t flags;	/* DATA/MDATA flag */
+	uint32_t count; /* Number of elements in the array if this is of an
+			 * array type, or number of members if this is a
+			 * record type. */
+	size_t meta_sz;
+	size_t data_sz;
+	STAILQ_ENTRY(ldms_mdef_s) entry;
+};
+
+STAILQ_HEAD(metric_list_head, ldms_mdef_s);
+
+struct ldms_schema_s {
+	char *name;
+	struct ldms_digest_s digest;
+	EVP_MD_CTX *evp_ctx;
+	int card;
+	size_t meta_sz;
+	size_t data_sz;
+	int array_card;
+	STAILQ_HEAD(, ldms_mdef_s) metric_list;
+	LIST_ENTRY(ldms_schema_s) entry;
+};
+
+/*
+ * This structure stores user-defined record definition constructed by
+ * ldms_record_create() and ldms_record_metric_add() APIs. This structure will
+ * later be used to create `ldms_record_type` in the set meta data.
+ */
+typedef struct ldms_record {
+	struct ldms_mdef_s mdef; /* base */
+	ldms_schema_t schema;
+	int metric_id;
+	int n; /* the number of members */
+	size_t inst_sz; /* the size of an instance */
+	size_t type_sz; /* the size of the record type (in metadata section) */
+	STAILQ_HEAD(, ldms_mdef_s) rec_metric_list;
+} *ldms_record_t;
+
+typedef struct ldms_record_array_def {
+	struct ldms_mdef_s mdef; /* base */
+	int rec_type; /* index to the record type */
+	int inst_sz;
+} *ldms_record_array_def_t;
+
+ldms_mdef_t ldms_schema_mdef_first(ldms_schema_t sch)
+{
+	return STAILQ_FIRST(&sch->metric_list);
+}
+
+ldms_mdef_t ldms_mdef_next(ldms_mdef_t mdef)
+{
+	return STAILQ_NEXT(mdef, entry);
+}
+
+enum ldms_value_type ldms_mdef_type(ldms_mdef_t mdef)
+{
+	return mdef->type;
+}
+
+const char *ldms_mdef_name(ldms_mdef_t mdef)
+{
+	return mdef->name;
+}
+
+const char *ldms_mdef_units(ldms_mdef_t mdef)
+{
+	return mdef->unit;
+}
+
+int ldms_mdef_array_len(ldms_mdef_t mdef)
+{
+	return mdef->count;
+}
+
+int ldms_mdef_list_heap_sz(ldms_mdef_t mdef)
+{
+	return mdef->count;
+}
+
+ldms_record_t ldms_mdef_record(ldms_mdef_t mdef)
+{
+	ldms_record_t rec = container_of(mdef, struct ldms_record, mdef);
+	return rec;
+}
+
+ldms_mdef_t ldms_record_mdef_first(ldms_record_t rec)
+{
+	return STAILQ_FIRST(&rec->rec_metric_list);
+}
+
+int ldms_mdef_is_meta(ldms_mdef_t mdef)
+{
+	return !!(mdef->flags & LDMS_MDESC_F_META);
+}

--- a/C/ldms_schema_access.h
+++ b/C/ldms_schema_access.h
@@ -1,0 +1,20 @@
+#ifndef __LDMS_SCHEMA_ACCESS_H__
+#define __LDMS_SCHEMA_ACCESS_H__
+
+#include "ldms/ldms.h"
+
+typedef struct ldms_mdef_s *ldms_mdef_t;
+
+ldms_mdef_t ldms_schema_mdef_first(ldms_schema_t sch);
+ldms_mdef_t ldms_mdef_next(ldms_mdef_t mdef);
+enum ldms_value_type ldms_mdef_type(ldms_mdef_t mdef);
+const char *ldms_mdef_name(ldms_mdef_t mdef);
+const char *ldms_mdef_units(ldms_mdef_t mdef);
+int ldms_mdef_array_len(ldms_mdef_t mdef);
+int ldms_mdef_list_heap_sz(ldms_mdef_t mdef);
+ldms_record_t ldms_mdef_record(ldms_mdef_t mdef);
+ldms_mdef_t ldms_record_mdef_first(ldms_record_t rec);
+
+int ldms_mdef_is_meta(ldms_mdef_t mdef);
+
+#endif

--- a/C/msr_client.c
+++ b/C/msr_client.c
@@ -1,0 +1,1206 @@
+#include <stdint.h>
+#include <malloc.h>
+#include <string.h>
+#include <errno.h>
+#include <curl/curl.h>
+#include <jansson.h>
+
+#include "msr_client.h"
+
+/* #include "ldms_schema_access.h" */
+
+#define URL_IDS "%s/schemas/ids/%s"
+#define URL_NAMES_LIST "%s/names"
+#define URL_NAMES_VERSIONS "%s/names/%s/versions"
+#define URL_DIGESTS_LIST "%s/digests"
+#define URL_DIGESTS_VERSIONS "%s/digests/%s/versions"
+
+typedef struct msr_buf_s *msr_buf_t;
+struct msr_buf_s {
+	size_t off;  /* next write location */
+	size_t alen; /* available length */
+	char *buf;  /* the buffer */
+};
+
+typedef ldms_metric_template_t ldms_mdef_t;
+
+struct msr_client_s {
+	int n;
+	int idx;
+	const char *ca_cert; /* path to ca_cer */
+	const char *urls[];
+
+	/*
+	 * msr_client_s contiguous memory format:
+	 * - n
+	 * - idx
+	 * - ca_cert ------------.
+	 * - urls[0] ------.     |
+	 * - urls[1] ------+-.   |
+	 * - ...           | |   |
+	 * - urls[n-1] ----+-+-. |
+	 * - urls_0_data <-' | | |
+	 * - urls_1_data <---' | |
+	 * - ...               | |
+	 * - urls_(n-1)_data <-' |
+	 * - ca_cert_data <------'
+	 */
+};
+
+#define MSR_CHUNKSZ 0x2000
+#define MSR_ROUNDUP(Z) ( ((Z)-1)&0x1FFF + 1 )
+
+static msr_buf_t __msr_buf_new()
+{
+	msr_buf_t b = malloc(sizeof(*b));
+	if (b) {
+		b->off = 0;
+		b->alen = MSR_CHUNKSZ;
+		b->buf = malloc(MSR_CHUNKSZ);
+		if (!b->buf) {
+			free(b);
+			b = NULL;
+		}
+	}
+	return b;
+}
+
+static int __msr_buf_extend(msr_buf_t b, size_t sz_more)
+{
+	void *tmp;
+	size_t sz = MSR_ROUNDUP(sz_more);
+	tmp = realloc(b->buf, b->alen + b->off + sz);
+	if (tmp) {
+		b->buf = tmp;
+		b->alen += sz;
+		return 0;
+	}
+	return ENOMEM;
+}
+
+static void __msr_buf_free(msr_buf_t b)
+{
+	free(b->buf);
+	free(b);
+}
+
+static size_t __curl_write_cb(void *data, size_t sz, size_t n, void *ctxt)
+{
+	size_t data_sz = sz * n;
+	msr_buf_t b = ctxt;
+	size_t sz_more;
+	int rc;
+	if (data_sz >= b->alen) {
+		sz_more = data_sz - b->alen;
+		rc = __msr_buf_extend(b, sz_more);
+		if (rc)
+			return 0;
+	}
+	memcpy(&b->buf[b->off], data, data_sz);
+	b->off += data_sz;
+	b->alen -= data_sz;
+	b->buf[b->off] = 0; /* always '\0' terminated */
+	return data_sz;
+}
+
+msr_client_t msr_client_new(const char *urls[], const char *ca_cert)
+{
+	int n, len;
+	const char *u;
+	msr_client_t cli;
+	size_t sz;
+
+	/* calculate size */
+	sz = sizeof(*cli);
+	for (n = 0; (u = urls[n]); n++) {
+		len = strlen(u) + 1;
+		sz += len;
+	}
+	if (ca_cert) {
+		len = strlen(ca_cert) + 1;
+		sz += len;
+	}
+	sz += sizeof(char*)*n;
+	cli = malloc(sz);
+	if (!cli)
+		return NULL;
+	cli->n = n;
+	cli->idx = 0;
+	u = (char*)&cli->urls[cli->n];
+	for (n = 0; n < cli->n; n++) {
+		cli->urls[n] = u;
+		strcpy((char*)u, urls[n]);
+		len = strlen(u) + 1;
+		u += len;
+	}
+	if (ca_cert) {
+		cli->ca_cert = u;
+		strcpy((char*)u, ca_cert);
+		len = strlen(u) + 1;
+		u += len;
+	} else {
+		cli->ca_cert = NULL;
+	}
+	return cli;
+}
+
+struct __json_type_ent_s {
+	const char *name;
+	enum ldms_value_type type;
+};
+
+static struct __json_type_ent_s __tbl[] = {
+	{ "d64",    LDMS_V_D64         },
+	{ "double", LDMS_V_D64         },
+	{ "f32",    LDMS_V_F32         },
+	{ "float",  LDMS_V_F32         },
+	{ "list",   LDMS_V_LIST        },
+	{ "long",   LDMS_V_S64         },
+	{ "record", LDMS_V_RECORD_TYPE },
+	{ "s16",    LDMS_V_S16         },
+	{ "s32",    LDMS_V_S32         },
+	{ "s64",    LDMS_V_S64         },
+	{ "s8",     LDMS_V_S8          },
+	{ "u16",    LDMS_V_U16         },
+	{ "u32",    LDMS_V_U32         },
+	{ "u64",    LDMS_V_U64         },
+	{ "u8",     LDMS_V_U8          },
+};
+
+static int __tbl_cmp(const void *_key, const void *_ent)
+{
+	const char *key = _key;
+	const struct __json_type_ent_s *ent = _ent;
+	return strcmp(key, ent->name);
+}
+
+enum ldms_value_type __json_field_type(json_t *o, int *_len)
+{
+	json_t *jtype = json_object_get(o, "type");
+	json_t *jitems = NULL, *jlen = NULL, *jheap_sz = NULL;
+	const char *stype = json_string_value(jtype);
+	struct __json_type_ent_s *ent;
+	enum ldms_value_type typ;
+
+	*_len = 1;
+
+	if (0 == strcmp(stype, "array")) {
+		jitems = json_object_get(o, "items");
+		stype = json_string_value(jitems); /* type of array element */
+		jlen = json_object_get(o, "len");
+		*_len = json_integer_value(jlen);
+	}
+
+	ent = bsearch(stype, __tbl, sizeof(__tbl)/sizeof(__tbl[0]),
+				    sizeof(__tbl[0]), __tbl_cmp);
+	if (!ent)
+		return LDMS_V_NONE;
+	typ = ent->type;
+	if (jitems) {
+		/* make it an array */;
+		if (typ == LDMS_V_RECORD_TYPE) {
+			typ = LDMS_V_RECORD_ARRAY;
+		} else {
+			typ += ( LDMS_V_CHAR_ARRAY - LDMS_V_CHAR );
+		}
+	}
+
+	if (typ == LDMS_V_LIST) {
+		jheap_sz = json_object_get(o, "heap_sz");
+		*_len = json_integer_value(jheap_sz);
+	}
+
+	return typ;
+}
+
+static int __ldms_record_add_json_metric(ldms_record_t rec, json_t *obj)
+{
+	json_t *jname;
+	int len, rc, idx;
+	enum ldms_value_type lvt;
+	if (json_typeof(obj) != JSON_OBJECT)
+		goto einval;
+
+	jname = json_object_get(obj, "name");
+	if (!jname || json_typeof(jname) != JSON_STRING)
+		goto einval;
+
+	lvt = __json_field_type(obj, &len);
+
+	switch (lvt) {
+	case LDMS_V_S8:  case LDMS_V_U8:
+	case LDMS_V_S16: case LDMS_V_U16:
+	case LDMS_V_S32: case LDMS_V_U32:
+	case LDMS_V_S64: case LDMS_V_U64:
+	case LDMS_V_F32: case LDMS_V_D64:
+
+	case LDMS_V_S8_ARRAY:  case LDMS_V_U8_ARRAY:
+	case LDMS_V_S16_ARRAY: case LDMS_V_U16_ARRAY:
+	case LDMS_V_S32_ARRAY: case LDMS_V_U32_ARRAY:
+	case LDMS_V_S64_ARRAY: case LDMS_V_U64_ARRAY:
+	case LDMS_V_F32_ARRAY: case LDMS_V_D64_ARRAY:
+		idx = ldms_record_metric_add(rec, json_string_value(jname), NULL,
+					    lvt, len);
+		if (idx < 0) {
+			rc = -idx;
+			goto out;
+		}
+		break;
+	case LDMS_V_NONE:
+	default:
+		goto einval;
+	}
+	rc = 0;
+	goto out;
+
+ einval:
+	rc = EINVAL;
+ out:
+	return rc;
+}
+
+static int __ldms_schema_add_json_metric(ldms_schema_t sch, json_t *obj)
+{
+	json_t *jname, *jfields, *jv, *junits, *jmeta, *jrecord_type;
+	int len, rc, idx, n, i;
+	enum ldms_value_type lvt;
+	ldms_record_t rec;
+	const char *record_type;
+	struct ldms_metric_template_s *tmp;
+	if (json_typeof(obj) != JSON_OBJECT)
+		goto einval;
+	jname = json_object_get(obj, "name");
+	if (!jname || json_typeof(jname) != JSON_STRING)
+		goto einval;
+	junits = json_object_get(obj, "units");
+	jmeta = json_object_get(obj, "is_meta");
+	lvt = __json_field_type(obj, &len);
+	switch (lvt) {
+	case LDMS_V_S8:  case LDMS_V_U8:
+	case LDMS_V_S16: case LDMS_V_U16:
+	case LDMS_V_S32: case LDMS_V_U32:
+	case LDMS_V_S64: case LDMS_V_U64:
+	case LDMS_V_F32: case LDMS_V_D64:
+		/* primitive metric */
+		if (json_is_true(jmeta)) {
+			idx = ldms_schema_meta_add_with_unit(sch,
+						json_string_value(jname),
+						json_string_value(junits), lvt);
+		} else {
+			idx = ldms_schema_metric_add_with_unit(sch,
+						json_string_value(jname),
+						json_string_value(junits), lvt);
+		}
+		if (idx < 0) {
+			rc = -idx;
+			goto out;
+		}
+		break;
+	case LDMS_V_S8_ARRAY:  case LDMS_V_U8_ARRAY:
+	case LDMS_V_S16_ARRAY: case LDMS_V_U16_ARRAY:
+	case LDMS_V_S32_ARRAY: case LDMS_V_U32_ARRAY:
+	case LDMS_V_S64_ARRAY: case LDMS_V_U64_ARRAY:
+	case LDMS_V_F32_ARRAY: case LDMS_V_D64_ARRAY:
+		/* array of primitives */
+		if (json_is_true(jmeta)) {
+			idx = ldms_schema_meta_array_add_with_unit(sch,
+					json_string_value(jname),
+					json_string_value(junits),
+					lvt, len);
+		} else {
+			idx = ldms_schema_metric_array_add(sch,
+					json_string_value(jname), lvt, len);
+		}
+		if (idx < 0) {
+			rc = -idx;
+			goto out;
+		}
+		break;
+	case LDMS_V_RECORD_TYPE:
+		/* "record" maps to RECORD_INST; but it actually defining the
+		 * type in JSON. */
+		jfields = json_object_get(obj, "fields");
+		if (!jfields || json_typeof(jfields) != JSON_ARRAY)
+			goto einval;
+		rec = ldms_record_create(json_string_value(jname));
+		if (!rec) {
+			rc = errno;
+			goto out;
+		}
+		json_array_foreach(jfields, idx, jv) {
+			if (json_typeof(jv) != JSON_OBJECT)
+				goto einval;
+			rc = __ldms_record_add_json_metric(rec, jv);
+			if (rc)
+				goto out;
+		}
+		idx = ldms_schema_record_add(sch, rec);
+		if (idx < 0) {
+			rc = -idx;
+			goto out;
+		}
+		rec = NULL; /* rec now belongs to the schema */
+		break;
+	case LDMS_V_RECORD_ARRAY:
+		/* get the rec_def first */
+		jrecord_type = json_object_get(obj, "record_type");
+		if (!json_is_string(jrecord_type))
+			goto einval;
+		record_type = json_string_value(jrecord_type);
+		n = ldms_schema_metric_count_get(sch);
+		tmp = malloc(sizeof(*tmp)*n);
+		if (!tmp) {
+			rc = errno;
+			goto out;
+		}
+		ldms_schema_bulk_template_get(sch, n, tmp);
+		for (i = 0; i < n; i++) {
+			if (0 == strcmp(tmp[i].name, record_type))
+				break;
+		}
+		if (i == n) {
+			/* not found */
+			free(tmp);
+			rc = EINVAL;
+			goto out;
+		}
+		idx = ldms_schema_record_array_add(sch, json_string_value(jname),
+					     tmp[i].rec_def, len);
+		free(tmp);
+		if (idx < 0) {
+			rc = -idx;
+			goto out;
+		}
+		break;
+	case LDMS_V_LIST:
+		idx = ldms_schema_metric_list_add(sch, json_string_value(jname),
+						 NULL, len);
+		if (idx < 0) {
+			rc = -idx;
+			goto out;
+		}
+		break;
+	case LDMS_V_NONE:
+	default:
+		goto einval;
+	}
+	rc = 0;
+	goto out;
+
+ einval:
+	rc = EINVAL;
+ out:
+	return rc;
+}
+
+static ldms_schema_t __json_to_ldms_schema(json_t *obj)
+{
+	json_t *_obj = NULL, *v, *a;
+	size_t idx;
+	int rc;
+	ldms_schema_t sch = NULL;
+	if (json_typeof(obj) != JSON_OBJECT) {
+		errno = EINVAL;
+		goto err;
+	}
+
+	_obj = json_object_get(obj, "schema");
+	if (_obj) { /* borrowed ref, do not decref(_obj) */
+		obj = _obj;
+	}
+
+	v = json_object_get(obj, "name"); /* borrowed ref, do not decref(v) */
+	if (!v)
+		goto einval;
+	if (json_typeof(v) != JSON_STRING)
+		goto einval;
+	sch = ldms_schema_new(json_string_value(v));
+	v = NULL;
+	a = json_object_get(obj, "fields");
+	if (!a)
+		goto einval;
+	json_array_foreach(a, idx, v) {
+		rc = __ldms_schema_add_json_metric(sch, v);
+		if (rc) {
+			errno = rc;
+			goto err;
+		}
+	}
+	return sch;
+
+ einval:
+	errno = EINVAL;
+ err:
+	if (sch)
+		ldms_schema_delete(sch);
+	return NULL;
+}
+
+static msr_buf_t __msr_url_post(msr_client_t msr, const char *url, json_t *obj,
+				CURLcode *_res)
+{
+	msr_buf_t b = NULL;
+	CURL *curl = NULL;
+	char *obj_str = NULL;
+	struct curl_slist *hdrs = NULL;
+	CURLcode res;
+	b = __msr_buf_new();
+	if (!b)
+		goto out;
+	curl = curl_easy_init();
+	if (!curl)
+		goto err;
+
+	res = curl_easy_setopt(curl, CURLOPT_URL, url);
+	if (res != CURLE_OK)
+		goto err;
+	if (msr->ca_cert) {
+		res = curl_easy_setopt(curl, CURLOPT_CAINFO, msr->ca_cert);
+		if (res != CURLE_OK)
+			goto err;
+	}
+
+	/* POST method */
+	res = curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "POST");
+	if (res != CURLE_OK)
+		goto err;
+
+	/* http request header & POST method */
+	hdrs = curl_slist_append(hdrs, "Content-Type: application/json");
+	res = curl_easy_setopt(curl, CURLOPT_HTTPHEADER, hdrs);
+	if (res != CURLE_OK)
+		goto err;
+
+	/* POST data (json) */
+	obj_str = json_dumps(obj, 0);
+	if (!obj_str)
+		goto err;
+	res = curl_easy_setopt(curl, CURLOPT_POSTFIELDS, obj_str);
+	if (res != CURLE_OK)
+		goto err;
+
+	/* setup recv data buffer */
+	res = curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, __curl_write_cb);
+	if (res != CURLE_OK)
+		goto err;
+	res = curl_easy_setopt(curl, CURLOPT_WRITEDATA, b);
+	if (res != CURLE_OK)
+		goto err;
+
+	res = curl_easy_perform(curl);
+	if (res != CURLE_OK)
+		goto err;
+
+	goto out;
+
+ err:
+	if (b) {
+		__msr_buf_free(b);
+		b = NULL;
+	}
+ out:
+	if (hdrs)
+		curl_slist_free_all(hdrs);
+	if (_res)
+		*_res = res;
+	if (curl)
+		curl_easy_cleanup(curl);
+	if (obj_str)
+		free(obj_str);
+	return b;
+}
+
+json_t *__ldms_mdef_to_json(ldms_mdef_t mdef);
+
+json_t *__ldms_record_to_json(const char *name, ldms_record_t rec)
+{
+	json_t *obj = NULL;
+	json_t *fields = NULL, *jval;
+	int rc, i, n;
+	struct ldms_metric_template_s *mdef = NULL;
+	obj = json_object();
+	rc = json_object_set_new(obj, "name", json_string(name));
+	if (rc)
+		goto err;
+	rc = json_object_set_new(obj, "type", json_string("record"));
+	if (rc)
+		goto err;
+	fields = json_array();
+	if (!fields)
+		goto err;
+	rc = json_object_set_new(obj, "fields", fields);
+	if (rc) {
+		json_decref(fields);
+		goto err;
+	}
+	n = ldms_record_metric_card(rec);
+	mdef = malloc(n * sizeof(mdef[0]));
+	ldms_record_bulk_template_get(rec, n, mdef);
+	for (i = 0; i < n; i++) {
+		jval = __ldms_mdef_to_json(&mdef[i]);
+		if (!jval)
+			goto err;
+		rc = json_array_append(fields, jval);
+		if (rc) {
+			json_decref(jval);
+			goto err;
+		}
+	}
+	goto out;
+ err:
+	if (obj) {
+		json_decref(obj);
+		obj = NULL;
+	}
+ out:
+	if (mdef)
+		free(mdef);
+	return obj;
+}
+
+json_t *__ldms_mdef_to_json(ldms_mdef_t mdef)
+{
+	ldms_record_t rec;
+	enum ldms_value_type vt;
+	json_t *obj = NULL;
+	json_t *jname = NULL, *jtype = NULL, *jitems = NULL, *jlen = NULL;
+	json_t *jrecord_type = NULL;
+	json_t *jheap_sz = NULL;
+	char buf[128];
+	const char *atype;
+	const char *units;
+	int alen, mlen;
+	obj = json_object();
+	if (!obj)
+		goto err;
+	jname = json_string(mdef->name);
+	if (!jname)
+		goto err;
+	json_object_set_new(obj, "name", jname); /* obj owns jname */
+	vt = mdef->type;
+	switch (vt) {
+	case LDMS_V_CHAR:
+	case LDMS_V_U8:
+	case LDMS_V_S8:
+	case LDMS_V_U16:
+	case LDMS_V_S16:
+	case LDMS_V_U32:
+	case LDMS_V_S32:
+	case LDMS_V_U64:
+	case LDMS_V_S64:
+	case LDMS_V_F32:
+	case LDMS_V_D64:
+		jtype = json_string(ldms_metric_type_to_str(vt));
+		if (!jtype)
+			goto err;
+		json_object_set_new(obj, "type", jtype);
+		break;
+	case LDMS_V_CHAR_ARRAY:
+	case LDMS_V_U8_ARRAY:
+	case LDMS_V_S8_ARRAY:
+	case LDMS_V_U16_ARRAY:
+	case LDMS_V_S16_ARRAY:
+	case LDMS_V_U32_ARRAY:
+	case LDMS_V_S32_ARRAY:
+	case LDMS_V_U64_ARRAY:
+	case LDMS_V_S64_ARRAY:
+	case LDMS_V_F32_ARRAY:
+	case LDMS_V_D64_ARRAY:
+		/* type */
+		jtype = json_string("array");
+		if (!jtype)
+			goto err;
+		json_object_set_new(obj, "type", jtype);
+		/* items */
+		atype = ldms_metric_type_to_str(vt);
+		alen = strlen(atype);
+		snprintf(buf, sizeof(buf), "%.*s", alen-2, atype); /* less [] */
+		jitems = json_string(buf);
+		if (!jitems)
+			goto err;
+		json_object_set_new(obj, "items", jitems);
+		/* len */
+		mlen = mdef->len;
+		jlen = json_integer(mlen);
+		if (!jlen)
+			goto err;
+		json_object_set_new(obj, "len", jlen);
+		break;
+	case LDMS_V_LIST:
+		/* type */
+		jtype = json_string("list");
+		if (!jtype)
+			goto err;
+		json_object_set_new(obj, "type", jtype);
+		/* heap_sz */
+		jheap_sz = json_integer(mdef->len);
+		if (!jheap_sz)
+			goto err;
+		json_object_set_new(obj, "heap_sz", jheap_sz);
+		break;
+	case LDMS_V_RECORD_TYPE:
+		/* type */
+		json_decref(obj); /* discard the object */
+		rec = mdef->rec_def;
+		obj = __ldms_record_to_json(mdef->name, rec);
+		break;
+	case LDMS_V_RECORD_ARRAY:
+		/* type */
+		jtype = json_string("array");
+		if (!jtype)
+			goto err;
+		json_object_set_new(obj, "type", jtype);
+		/* items */
+		atype = ldms_metric_type_to_str(vt);
+		alen = strlen(atype);
+		snprintf(buf, sizeof(buf), "%.*s", alen-2, atype); /* less [] */
+		jitems = json_string(buf);
+		if (!jitems)
+			goto err;
+		json_object_set_new(obj, "items", jitems);
+		/* len */
+		mlen = mdef->len;
+		jlen = json_integer(mlen);
+		if (!jlen)
+			goto err;
+		json_object_set_new(obj, "len", jlen);
+		/* record_type */
+		jrecord_type = json_string(ldms_record_name_get(mdef->rec_def));
+		if (!jrecord_type)
+			goto err;
+		json_object_set_new(obj, "record_type", jrecord_type);
+		break;
+	case LDMS_V_LIST_ENTRY:
+	case LDMS_V_RECORD_INST:
+	case LDMS_V_TIMESTAMP:
+	case LDMS_V_NONE:
+	default:
+		errno = EINVAL;
+		goto err;
+	}
+
+	units = mdef->unit;
+	if (units) {
+		json_object_set_new(obj, "units", json_string(units));
+	}
+
+	if (mdef->flags & LDMS_MDESC_F_META) {
+		json_object_set_new(obj, "is_meta", json_boolean(1));
+	}
+
+	goto out;
+
+ err:
+	if (obj) {
+		json_decref(obj);
+		obj = NULL;
+	}
+ out:
+	return obj;
+}
+
+json_t *__ldms_schema_to_json(ldms_schema_t sch)
+{
+	json_t *obj, *fields, *f;
+	int rc, i, n;
+	const char *name;
+	struct ldms_metric_template_s *mdef = NULL;
+
+	obj = json_object();
+	if (!obj)
+		goto out;
+	rc = json_object_set_new(obj, "type", json_string("record"));
+	if (rc)
+		goto err;
+	name = ldms_schema_name_get(sch);
+	rc = json_object_set_new(obj, "name", json_string(name));
+	if (rc)
+		goto err;
+	fields = json_array();
+	rc = json_object_set_new(obj, "fields", fields);
+	/* NOTE: `fields` ref is stolen; `fields` belongs to `obj` */
+	if (rc)
+		goto err;
+	n = ldms_schema_metric_count_get(sch);
+	mdef = malloc(n*sizeof(mdef[0]));
+	if (!mdef)
+		goto err;
+	ldms_schema_bulk_template_get(sch, 1024, mdef);
+	for (i = 0; i < n; i++) {
+		f = __ldms_mdef_to_json(&mdef[i]);
+		if (!f)
+			goto err;
+		json_array_append_new(fields, f); /* f belongs to fields */
+	}
+
+	goto out;
+
+ err:
+	if (obj)
+		json_decref(obj);
+	obj = NULL;
+ out:
+	if (mdef)
+		free(mdef);
+	return obj;
+}
+
+int msr_ldms_schema_add(msr_client_t msr, ldms_schema_t sch, char **id_out)
+{
+	json_t *obj = NULL;
+	json_t *jid = NULL;
+	json_error_t jerr;
+	int rc = ENOSYS;
+	CURLcode res;
+	msr_buf_t b = NULL;
+
+	obj = __ldms_schema_to_json(sch);
+	if (!obj) {
+		rc = errno;
+		goto out;
+	}
+
+	b = __msr_url_post(msr, msr->urls[msr->idx], obj, &res);
+	if (!b) {
+		rc = EINVAL;
+		goto out;
+	}
+	json_decref(obj); /* drop old obj */
+
+	obj = json_loads(b->buf, 0, &jerr);
+	if (!json_is_object(obj)) {
+		rc = EINVAL;
+		goto out;
+	}
+	jid = json_object_get(obj, "id"); /* borrowed ref; decref not needed */
+	if (!json_is_string(jid)) {
+		rc = EINVAL;
+		goto out;
+	}
+	*id_out = strdup(json_string_value(jid));
+	rc = 0;
+
+ out:
+	if (obj)
+		json_decref(obj);
+	if (b)
+		__msr_buf_free(b);
+	return rc;
+}
+
+static msr_buf_t __msr_url_get(msr_client_t msr, const char *url, CURLcode *_res)
+{
+	msr_buf_t b = NULL;
+	CURL *curl = NULL;
+	CURLcode res;
+	b = __msr_buf_new();
+	if (!b)
+		goto out;
+	curl = curl_easy_init();
+	if (!curl)
+		goto err;
+
+	res = curl_easy_setopt(curl, CURLOPT_URL, url);
+	if (res != CURLE_OK)
+		goto err;
+	if (msr->ca_cert) {
+		res = curl_easy_setopt(curl, CURLOPT_CAINFO, msr->ca_cert);
+		if (res != CURLE_OK)
+			goto err;
+	}
+
+	/* setup data buffer */
+	res = curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, __curl_write_cb);
+	if (res != CURLE_OK)
+		goto err;
+	res = curl_easy_setopt(curl, CURLOPT_WRITEDATA, b);
+	if (res != CURLE_OK)
+		goto err;
+
+	res = curl_easy_perform(curl);
+	if (res != CURLE_OK)
+		goto err;
+
+	goto out;
+ err:
+	if (b) {
+		__msr_buf_free(b);
+		b = NULL;
+	}
+ out:
+	if (_res)
+		*_res = res;
+	if (curl)
+		curl_easy_cleanup(curl);
+	return b;
+}
+
+static msr_buf_t __msr_url_del(msr_client_t msr, const char *url, CURLcode *_res)
+{
+	msr_buf_t b = NULL;
+	CURL *curl = NULL;
+	CURLcode res;
+	b = __msr_buf_new();
+	if (!b)
+		goto out;
+	curl = curl_easy_init();
+	if (!curl)
+		goto err;
+
+	res = curl_easy_setopt(curl, CURLOPT_URL, url);
+	if (res != CURLE_OK)
+		goto err;
+	if (msr->ca_cert) {
+		res = curl_easy_setopt(curl, CURLOPT_CAINFO, msr->ca_cert);
+		if (res != CURLE_OK)
+			goto err;
+	}
+
+	/* DELETE method */
+	res = curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "DELETE");
+	if (res != CURLE_OK)
+		goto err;
+
+	/* setup data buffer */
+	res = curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, __curl_write_cb);
+	if (res != CURLE_OK)
+		goto err;
+	res = curl_easy_setopt(curl, CURLOPT_WRITEDATA, b);
+	if (res != CURLE_OK)
+		goto err;
+
+	res = curl_easy_perform(curl);
+	if (res != CURLE_OK)
+		goto err;
+
+	goto out;
+ err:
+	if (b) {
+		__msr_buf_free(b);
+		b = NULL;
+	}
+ out:
+	if (_res)
+		*_res = res;
+	if (curl)
+		curl_easy_cleanup(curl);
+	return b;
+}
+
+ldms_schema_t msr_ldms_schema_get(msr_client_t msr, const char *id)
+{
+	int n;
+	ldms_schema_t sch = NULL;
+	CURLcode res;
+	char url[BUFSIZ];
+	msr_buf_t b = NULL;
+	json_t *obj = NULL;
+	json_error_t jerr;
+
+	n = snprintf(url, sizeof(url), URL_IDS, msr->urls[msr->idx], id);
+	if (n >= sizeof(url)) {
+		/* unlikely */
+		errno = ENAMETOOLONG;
+		goto out;
+	}
+
+	b = __msr_url_get(msr, url, &res);
+	if (!b)
+		goto out;
+
+	obj = json_loads(b->buf, 0, &jerr);
+	if (!obj) {
+		errno = EINVAL;
+		goto out;
+	}
+	sch = __json_to_ldms_schema(obj);
+ out:
+	if (b)
+		__msr_buf_free(b);
+	if (obj)
+		json_decref(obj);
+	return sch;
+}
+
+int msr_ldms_schema_del(msr_client_t msr, const char *id)
+{
+	int rc;
+	int n;
+	CURLcode res;
+	char url[BUFSIZ];
+	msr_buf_t b = NULL;
+	json_t *obj = NULL, *jid;
+	json_error_t jerr;
+
+	n = snprintf(url, sizeof(url), URL_IDS, msr->urls[msr->idx], id);
+	if (n >= sizeof(url)) {
+		/* unlikely */
+		rc = ENAMETOOLONG;
+		goto out;
+	}
+
+	b = __msr_url_del(msr, url, &res);
+	if (!b) {
+		rc = errno;
+		goto out;
+	}
+
+	obj = json_loads(b->buf, 0, &jerr);
+	if (json_typeof(obj) != JSON_ARRAY) {
+		rc = EINVAL;
+		goto out;
+	}
+	jid = json_array_get(obj, 0); /* borrowed ref; decref not needed */
+	if (!jid || json_typeof(jid) != JSON_STRING) {
+		rc = EINVAL;
+		goto out;
+	}
+	if (strcmp(json_string_value(jid), id)) {
+		rc = EINVAL;
+		goto out;
+	}
+	rc = 0;
+ out:
+	if (b)
+		__msr_buf_free(b);
+	if (obj)
+		json_decref(obj);
+	return rc;
+}
+
+msr_results_t msr_names_list(msr_client_t msr)
+{
+	CURLcode res;
+	int n;
+	char url[BUFSIZ];
+	msr_buf_t b = NULL;
+	json_t *obj = NULL;
+	json_t *v;
+	json_error_t jerr;
+	msr_results_t mres = NULL;
+	size_t msz;
+	char *s;
+
+	n = snprintf(url, sizeof(url), URL_NAMES_LIST, msr->urls[msr->idx]);
+	if (n >= sizeof(url)) {
+		/* unlikely */
+		errno = ENAMETOOLONG;
+		goto out;
+	}
+
+	b = __msr_url_get(msr, url, &res);
+	if (!b)
+		goto out;
+	obj = json_loads(b->buf, 0, &jerr);
+	if (!obj) {
+		errno = EINVAL;
+		goto out;
+	}
+	if (json_typeof(obj) != JSON_ARRAY) {
+		errno = EINVAL;
+		goto out;
+	}
+
+	/* calculate size */
+	msz = sizeof(*mres);
+	json_array_foreach(obj, n, v) {
+		msz += sizeof(char *);
+		if (json_typeof(v) != JSON_STRING) {
+			errno = EINVAL;
+			goto out;
+		}
+		msz += strlen(json_string_value(v)) + 1;
+	}
+	mres = malloc(msz);
+	if (!mres)
+		goto out;
+
+	/* now fill the values */
+	mres->n = n;
+	s = (char*)&mres->names[n];
+	json_array_foreach(obj, n, v) {
+		strcpy(s, json_string_value(v));
+		mres->names[n] = s;
+		s += strlen(s) + 1;
+	}
+	assert( ((void*)mres) + msz == (void*)s );
+ out:
+	if (b)
+		__msr_buf_free(b);
+	return mres;
+}
+
+static int __digest_from_str(ldms_digest_t d, const char *s)
+{
+	const char *p;
+	int n;
+	p = s;
+	n = 0;
+	while (*p && n < sizeof(d->digest)) {
+		sscanf(p, "%02hhx", &d->digest[n]);
+		n++;
+		p+=2;
+	}
+	if (*p || n < sizeof(d->digest)) {
+		return EINVAL;
+	}
+	return 0;
+}
+
+msr_results_t msr_digests_list(msr_client_t msr)
+{
+	CURLcode res;
+	int n, rc;
+	char url[BUFSIZ];
+	msr_buf_t b = NULL;
+	json_t *obj = NULL;
+	json_t *v;
+	json_error_t jerr;
+	msr_results_t mres = NULL;
+	size_t msz;
+
+	n = snprintf(url, sizeof(url), URL_DIGESTS_LIST, msr->urls[msr->idx]);
+	if (n >= sizeof(url)) {
+		/* unlikely */
+		errno = ENAMETOOLONG;
+		goto out;
+	}
+
+	b = __msr_url_get(msr, url, &res);
+	if (!b)
+		goto out;
+	obj = json_loads(b->buf, 0, &jerr);
+	if (!obj) {
+		errno = EINVAL;
+		goto out;
+	}
+	if (json_typeof(obj) != JSON_ARRAY) {
+		errno = EINVAL;
+		goto out;
+	}
+
+	/* calculate size */
+	n = json_array_size(obj);
+	msz = sizeof(*mres) + n*sizeof(mres->digests[0]);
+	mres = malloc(msz);
+	if (!mres)
+		goto out;
+
+	/* now fill the values */
+	mres->n = n;
+	json_array_foreach(obj, n, v) {
+		if (json_typeof(v) != JSON_STRING) {
+			errno = EINVAL;
+			goto err;
+		}
+		rc = __digest_from_str(&mres->digests[n], json_string_value(v));
+		if (rc) {
+			errno = rc;
+			goto err;
+		}
+	}
+	goto out;
+
+ err:
+	free(mres);
+ out:
+	if (b)
+		__msr_buf_free(b);
+	return mres;
+}
+
+msr_results_t msr_versions_list(msr_client_t msr, const char *name,
+				ldms_digest_t digest)
+{
+	return msr_ids_list(msr, name, digest);
+}
+
+msr_results_t msr_ids_list(msr_client_t msr, const char *name,
+			   ldms_digest_t digest)
+{
+	/* list ids by name or digest */
+	CURLcode res;
+	int n;
+	char url[BUFSIZ];
+	char digest_str[128];
+	msr_buf_t b = NULL;
+	json_t *obj = NULL;
+	json_t *v;
+	json_error_t jerr;
+	msr_results_t mres = NULL;
+	size_t msz;
+	char *s;
+
+	if (name) {
+		n = snprintf(url, sizeof(url), URL_NAMES_VERSIONS,
+					msr->urls[msr->idx], name);
+		if (n >= sizeof(url)) {
+			/* unlikely */
+			errno = ENAMETOOLONG;
+			goto out;
+		}
+	} else if (digest) {
+		ldms_digest_str(digest, digest_str, sizeof(digest_str));
+		n = snprintf(url, sizeof(url), URL_DIGESTS_VERSIONS,
+					msr->urls[msr->idx], digest_str);
+		if (n >= sizeof(url)) {
+			/* unlikely */
+			errno = ENAMETOOLONG;
+			goto out;
+		}
+	} else {
+		errno = EINVAL;
+		goto out;
+	}
+
+	b = __msr_url_get(msr, url, &res);
+	if (!b)
+		goto out;
+	obj = json_loads(b->buf, 0, &jerr);
+	if (!obj) {
+		errno = EINVAL;
+		goto out;
+	}
+	if (json_typeof(obj) == JSON_NULL) {
+		errno = ENOENT;
+		goto out;
+	}
+	if (json_typeof(obj) != JSON_ARRAY) {
+		errno = EINVAL;
+		goto out;
+	}
+
+	/* calculate size */
+	msz = sizeof(*mres);
+	json_array_foreach(obj, n, v) {
+		msz += sizeof(char *);
+		if (json_typeof(v) != JSON_STRING) {
+			errno = EINVAL;
+			goto out;
+		}
+		msz += strlen(json_string_value(v)) + 1;
+	}
+	mres = malloc(msz);
+	if (!mres)
+		goto out;
+
+	/* now fill the values */
+	mres->n = n;
+	s = (char*)&mres->ids[n];
+	json_array_foreach(obj, n, v) {
+		strcpy(s, json_string_value(v));
+		mres->ids[n] = s;
+		s += strlen(s) + 1;
+	}
+	assert( ((void*)mres) + msz == (void*)s );
+ out:
+	if (b)
+		__msr_buf_free(b);
+	return mres;
+}
+
+__attribute((constructor))
+void __init__()
+{
+	curl_global_init(CURL_GLOBAL_DEFAULT);
+}

--- a/C/msr_client.h
+++ b/C/msr_client.h
@@ -1,0 +1,49 @@
+/*
+ */
+#ifndef __MSR_CLIENT_H__
+#define __MSR_CLIENT_H__
+
+#include <ldms/ldms.h>
+
+typedef struct msr_client_s *msr_client_t;
+
+/**
+ * \brief Create a Maestro Schema Registry (MSR) client.
+ *
+ * \param urls NULL terminated string array. Each element is the URL to the
+ *             server.
+ * \retval cli The client handler.
+ */
+msr_client_t msr_client_new(const char *urls[], const char *ca_cert);
+
+typedef struct msr_results_s {
+	int n;
+	union {
+		const char *names[0];
+		const char *ids[0];
+		struct ldms_digest_s digests[0];
+	};
+} *msr_results_t;
+
+/**
+ * Add a schema to MSR server.
+ *
+ * \retval 0 If success, or
+ * \retval errno If error.
+ */
+int msr_ldms_schema_add(msr_client_t msr, ldms_schema_t schema, char **id_out);
+
+ldms_schema_t msr_ldms_schema_get(msr_client_t msr, const char *id);
+int msr_ldms_schema_del(msr_client_t msr, const char *id);
+
+msr_results_t msr_names_list(msr_client_t msr);
+msr_results_t msr_digests_list(msr_client_t msr);
+
+msr_results_t msr_versions_list(msr_client_t msr, const char *name,
+				ldms_digest_t digest);
+
+msr_results_t msr_ids_list(msr_client_t msr, const char *name,
+			   ldms_digest_t digest);
+
+
+#endif

--- a/C/msr_test.c
+++ b/C/msr_test.c
@@ -1,0 +1,261 @@
+#include <stdio.h>
+#include <getopt.h>
+#include <getopt.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <ldms/ldms.h>
+
+#include "msr_client.h"
+
+const char *short_opts = "aNDs:x:U:C:d:";
+
+struct option long_opts[] = {
+	{"add-schema",   0, 0, 'a'}, /* add a pre-defined test schema */
+	{"del-schema",   1, 0, 'd'}, /* delete a schema */
+	{"list-names",   0, 0, 'N'},
+	{"list-digests", 0, 0, 'D'},
+	{"xprt",         1, 0, 'x'},
+	{"set-schema",   1, 0, 's'},
+	{"urls",         1, 0, 'U'},
+	{"ca-cert",      1, 0, 'C'},
+	{0},
+};
+
+const char *__usage = "\
+msr_test [-a|-N|-D| -x XPRT[:PORT[:ADDR]] -s SCHEMA_ID] \n\
+	 -U SCHEMA_REGISTRY_LIST\n\
+	 [-C CA_CERT_PATH]\n\
+\n\
+	 -a, -d, -N, -D, and -x are mutually exclusive operations.\n\
+\n\
+	 -a  to add a pre-defined schema to the schema registry.\n\
+	 -N  to list schema ids by names.\n\
+	 -D  to list schema ids by digests.\n\
+\n\
+	 -x XPRT[:PORT[:ADDR]]  -s SCHEMA_ID\n\
+	    To listen to the given transport/port/addr and create an LDMS \n\
+	    set with the schema from the schema registry with the specified \n\
+	    SCHEMA_ID.\n\
+\n\
+	 -U SCHEMA_REGISTRY_URL_LIST\n\
+	    A comma-separated list of schema registry URLs.\n\
+\n\
+	 [-C CA_CERT_PATH]\n\
+	    An optional path to the custom CA Certificate (e.g. self-signed).\n\
+";
+
+void print_usage()
+{
+	printf("%s", __usage);
+}
+
+void do_add_schema(msr_client_t msr)
+{
+	int rc = 0, m;
+	ldms_record_t rec;
+	ldms_schema_t sch;
+	char *id_test;
+
+	struct ldms_metric_template_s rec_tmp[] = {
+		{ "uno", LDMS_MDESC_F_DATA, LDMS_V_S64, "u_uno", },
+		{ "dos", LDMS_MDESC_F_DATA, LDMS_V_S64, "u_dos", },
+		{0}
+	};
+	rec = ldms_record_from_template("rec", rec_tmp, NULL);
+
+	struct ldms_metric_template_s sch_tmp[] = {
+		{ "one", LDMS_MDESC_F_DATA, LDMS_V_S64, "u_one", },
+		{ "two", LDMS_MDESC_F_META, LDMS_V_S64, "u_two", },
+		{ "three", LDMS_MDESC_F_DATA, LDMS_V_D64, "u_three", 10, },
+		{ "rec", 0 /* ignored */, LDMS_V_RECORD_TYPE, NULL, 1, rec },
+		{ "rec_array", LDMS_MDESC_F_DATA, LDMS_V_RECORD_ARRAY, NULL, 8, rec },
+		{ "u32_array", LDMS_MDESC_F_DATA, LDMS_V_U32_ARRAY, NULL, 4, NULL },
+		{ "list", LDMS_MDESC_F_DATA, LDMS_V_LIST, NULL, 512, },
+		{0}
+	};
+
+	sch = ldms_schema_from_template("test", sch_tmp, &m);
+	rc = msr_ldms_schema_add(msr, sch, &id_test);
+	if (0 == rc) {
+		printf("id: %s\n", id_test);
+		free(id_test);
+	} else {
+		printf("error: %d\n", rc);
+	}
+}
+
+void do_del_schema(msr_client_t msr, const char *del_id)
+{
+	int rc;
+	rc = msr_ldms_schema_del(msr, del_id);
+	if (0 == rc) {
+		printf("id: %s\n", del_id);
+	} else {
+		printf("error: %d\n", rc);
+	}
+}
+
+void do_list_names(msr_client_t msr)
+{
+	msr_results_t names, ids;
+	int i, j;
+	names = msr_names_list(msr);
+	for (i = 0; i < names->n; i++) {
+		printf("%s:\n", names->names[i]);
+		ids = msr_ids_list(msr, names->names[i], NULL);
+		for (j = 0; j < ids->n; j++) {
+			printf(" - %s\n", ids->ids[j]);
+		}
+		free(ids);
+	}
+	free(names);
+}
+
+void do_list_digests(msr_client_t msr)
+{
+	msr_results_t digests, ids;
+	int i, j;
+	char buf[BUFSIZ];
+	digests = msr_digests_list(msr);
+	for (i = 0; i < digests->n; i++) {
+		/* print digest */
+		ldms_digest_str(&digests->digests[i], buf, sizeof(buf));
+		printf("%s:\n", buf);
+		ids = msr_ids_list(msr, NULL, &digests->digests[i]);
+		for (j = 0; j < ids->n; j++) {
+			printf(" - %s\n", ids->ids[j]);
+		}
+		free(ids);
+	}
+	free(digests);
+}
+
+void do_listen(msr_client_t msr, const char *id, const char *xprt,
+		const char *host, const char *port)
+{
+	ldms_schema_t sch;
+	ldms_t x;
+	ldms_set_t lset;
+	const char *name;
+	char buf[BUFSIZ];
+	int len;
+
+	sch = msr_ldms_schema_get(msr, id);
+	if (!sch) {
+		printf("cannot get schema '%s', errno: %d\n", id, errno);
+		return;
+	}
+
+	x = ldms_xprt_new(xprt);
+	ldms_xprt_listen_by_name(x, host, port, NULL, NULL);
+
+	gethostname(buf, sizeof(buf));
+	len = strlen(buf);
+	name = ldms_schema_name_get(sch);
+	snprintf(buf + len, BUFSIZ - len, "/%s", name);
+	lset = ldms_set_new(buf, sch);
+	ldms_set_publish(lset);
+	while (1) {
+		sleep(1);
+		ldms_transaction_begin(lset);
+		ldms_transaction_end(lset);
+	}
+}
+
+void set_op(char c, char *op)
+{
+	if (*op) {
+		printf("already have operation '-%c',"
+		       " but also got '-%c'\n", *op, c);
+		exit(0);
+	}
+	*op = c;
+}
+
+int main(int argc, char **argv)
+{
+	msr_client_t msr;
+	char c;
+	char op = 0;
+	int n_urls = 0;
+	char *tok, *tmp;
+	const char *urls[1024] = {0}; /* should be more than enough */
+	char *arg_xprt = NULL;
+	const char *_xprt = NULL, *_host = NULL, *_port = NULL;
+	const char *arg_set_schema = NULL;
+	const char *arg_ca_cert = NULL;
+	const char *del_id = NULL;
+
+	ldms_init(16*1024*1024);
+
+ next_arg:
+	c = getopt_long(argc, argv, short_opts, long_opts, NULL);
+	switch (c) {
+	case -1:
+		goto arg_done;
+	case 'a':
+	case 'N':
+	case 'D':
+		set_op(c, &op);
+		break;
+	case 'd':
+		set_op(c, &op);
+		del_id = optarg;
+		break;
+	case 's':
+		arg_set_schema = optarg;
+		break;
+	case 'x':
+		set_op(c, &op);
+		arg_xprt = optarg;
+		break;
+	case 'U':
+		tok = strtok_r(optarg, ",", &tmp);
+		while (tok) {
+			urls[n_urls++] = tok;
+			tok = strtok_r(NULL, ",", &tmp);
+		}
+		break;
+	case 'C':
+		arg_ca_cert = optarg;
+		break;
+	default:
+		print_usage();
+		exit(-1);
+	}
+	goto next_arg;
+
+ arg_done:
+
+	msr = msr_client_new(urls, arg_ca_cert);
+	if (!msr) {
+		printf("Cannot create registry client, errno: %d\n", errno);
+		exit(-1);
+	}
+
+	switch (op) {
+	case 'a':
+		do_add_schema(msr);
+		break;
+	case 'd':
+		do_del_schema(msr, del_id);
+		break;
+	case 'N':
+		do_list_names(msr);
+		break;
+	case 'D':
+		do_list_digests(msr);
+		break;
+	case 'x':
+		_xprt = strtok_r(arg_xprt, ":", &tmp);
+		_port = strtok_r(NULL, ":", &tmp);
+		if (_port) {
+			_host = strtok_r(NULL, ":", &tmp);
+		}
+		do_listen(msr, arg_set_schema, _xprt, _host, _port);
+		break;
+	}
+
+	return 0;
+}

--- a/scripts/maestro
+++ b/scripts/maestro
@@ -258,6 +258,7 @@ class MaestroMonitor(object):
                                             ep['auth']['plugin'],
                                             { 'conf' : conf })
                     except Exception as e:
+                        raise
                         print(f'Error initializing transport to ldmsd {dmn_name} at endpoint {ep_name} '\
                               f'on port {ep["port"]} with transport {ep["xprt"]}')
                         print(f'{e}')
@@ -1293,6 +1294,13 @@ if __name__ == "__main__":
     # have multiple monitoring hosted by the same consensus cluster.
 
     maestro = MaestroMonitor(etcd_spec, args)
+
+    # schemaregistry
+    sr_config = etcd_spec.get('schema_registry')
+    if sr_config:
+        from maestro.schema_registry import SchemaRegistry
+        sr = SchemaRegistry(etcd_spec)
+        sr.start()
 
     # At each load-balance group level the aggregators have all
     # producers; however, only the producers assigned to each

--- a/src/maestro/client.py
+++ b/src/maestro/client.py
@@ -1,0 +1,16 @@
+#!/usr/bin/python3
+
+import json
+import requests
+from schema_registry import *
+
+auth = requests.auth.HTTPBasicAuth('someone', 'something')
+ca_cert = '/db/cert.pem'
+cli = SchemaRegistryClient(['https://localhost:8080'], auth=auth, ca_cert=ca_cert)
+
+m = cli.list_versions(name = 'madeup')
+_id = m[0]
+s1 = cli.get_schema(_id = _id)
+
+obj = json.load(open('/db/schema2.json'))
+s2 = Schema.from_dict(obj)

--- a/src/maestro/schema_registry.py
+++ b/src/maestro/schema_registry.py
@@ -1,0 +1,1376 @@
+#!/usr/bin/python3
+
+import os
+import sys
+import threading
+import pdb
+import socket
+import logging
+import etcd3
+import json
+import enum
+import hashlib
+import requests
+from ovis_ldms import ldms
+
+from functools import wraps, cached_property
+
+from flask import Flask, Blueprint, current_app, g, request, Response
+from gevent.pywsgi import WSGIServer
+
+# Module doc
+__doc__ = r"""
+schema_registry
+
+
+SchemaRegistry (the server)
+---------------------------
+
+The `SchemaRegistry` object contains a routine to serve LDMS Schema Registry
+Service over HTTP (or HTTPS). The application can deploy the service as follows:
+
+>>> svc = SchemaRegistry( etcd_spec )
+>>> svc.start()
+
+The `etcd_spec` is a `dict` containing `etcd` configuration with extra
+`"schema_registry"` section. The following is an example of a `schema_registry`
+yaml configuration.
+
+```
+schema_registry
+  etcd_prefix: "/headnode/schema-registry"
+  listen: "*:8080"
+  keyfile: "/db/key.pem"
+  certfile: "/db/cert.pem"
+  auth:
+    type: simple
+    users:
+     - username: someone
+       password: something
+     - username: anotherone
+       password: anotherthing
+```
+
+Description for each option:
+- `etcd_prefix` is the prefix in ETCD database to store Schema Reigstry data
+- `listen` is an "_ADDRESS_:_PORT_" to listen and serve HTTP (or HTTPS) Schema
+  Registry Service.
+- `keyfile` is the private SSL/TLS key for HTTPS. If this option is specified,
+  the service is served over HTTPS.
+- `certfile` is the SSL/TLS certificate (public) for HTTPS. This is required to
+  serve over hTTPS.
+- `auth` is the authentication option section, which can specify `type` for the
+  type of the authentication method. Different authentication method may require
+  different additional parameters.
+  - `type` currently we only support "simple" (Simple HTTP) authentication, in
+    which `users` can be defined as a list of username-password dictionary as
+    shown in the example above.
+
+
+SchemaRegistryClient (the client)
+---------------------------------
+
+The client application can use SchemaRegistryClient as follows:
+>>> urls = [ "https://someone:something@host1:8080",
+...          "https://someone:something@host2:8080" ] # list of 1 URL is OK too
+>>> cli = SchemaRegistryClient(urls, ca_cert = "/db/cert.pem")
+
+The multiple entries of `urls` is for availability. If the current server became
+unavailable (e.g. down), the client will internally try the next one in a
+round-robin fashion. If all servers are not available, an exception will be
+raised.
+
+The `ca_cert` option is useful for self-signed certificate of the Schema
+Registry Server. If the certificate is signed by a Trusted Certificate Authority
+(e.g. signed by a CA in /etc/ssl/certs/), the `ca_cert` is not required.
+
+
+Schema JSON Format
+------------------
+
+The format is inspired by Avro Schema JSON format
+(https://avro.apache.org/docs/1.11.1/specification/),
+with LDMS-specific twists. The client uses the following format to submit (PUT)
+schema definition to the schema registry.
+
+```json
+  {
+    "name": _SCHEMA_NAME_,
+    "type": _TYPE_NAME_ , // usually "record"
+    "fields": [ // describing the "record"
+      { "name": _METRIC_NAME_, "type": _METRIC_TYPE_ },
+      ...
+    ]
+  }
+```
+
+The PUT request shall encapsulate the schema inside a JSON document under the
+"schema" attribute. For example,
+
+```json
+  {
+    "schema": {
+      "name" : _SCHEMA_NAME_,
+      ...
+    }
+  }
+```
+or,
+```json
+  {
+    "schema": "{ \"name\": \"_SCHEMA_NAME_\", ... }"
+    // JSON object encoded in string
+  }
+```
+
+
+"""
+
+log = logging.getLogger(__name__)
+
+class SchemaReigstryDebug(object):
+    pass
+
+_SD = SchemaReigstryDebug()
+
+#------------------------#
+#                        #
+# blueprint for WSGI app #
+#                        #
+#------------------------#
+
+blueprint = Blueprint('root', __name__,  url_prefix='')
+_SD.blueprint = blueprint
+_SD.name = __name__
+
+def json_resp(content):
+    return Response(content, mimetype="application/json")
+
+@blueprint.errorhandler(Exception)
+def error_handler(e):
+    if sys.flags.interactive:
+        pdb.post_mortem(e.__traceback__)
+
+@blueprint.before_request
+def auth_check():
+    sr = current_app.sr
+    if sr.auth:
+        failed_reason = sr.auth.authorize()
+        if failed_reason:
+            return failed_reason
+    return None
+
+@blueprint.get('/')
+def index_GET():
+    return f'index'
+
+@blueprint.post('/')
+def index_POST():
+    sr = current_app.sr
+    obj = request.json # The JSON object in the PUT request
+    if not obj:
+        return f'Missing input JSON object', 500
+    s = Schema.from_dict(obj)
+    sr.add_schema(s)
+    return json_resp(json.dumps({"id": s.id}))
+
+URL_SCHEMAS_IDS = '/schemas/ids/<_id>'
+@blueprint.get(URL_SCHEMAS_IDS)
+def schemas_ids_id_GET(_id):
+    sr = current_app.sr
+    sch = sr.get_schema(_id)
+    ret = sch.as_json()
+    return json_resp(ret)
+
+@blueprint.delete(URL_SCHEMAS_IDS)
+def schemas_ids_id_DEL(_id):
+    sr = current_app.sr
+    sr.delete_schema(_id = _id)
+    return json_resp(json.dumps([ _id ]))
+
+URL_NAMES_DIR = '/names'
+@blueprint.get(URL_NAMES_DIR)
+@blueprint.get('/subjects')
+def names_GET():
+    # GET to list schemas
+    # PUT to add a (potentially new) schema into etcd. The SHA of the schema is
+    #     used as schema ID, and schema 'name'
+    #
+    # schema object in etcd will have the following attributes:
+    #   - name
+    #   - id (sha)
+    #   - create_timestamp
+    #   - metrics: (array)
+    #     - name
+    #     - type
+    sr = current_app.sr
+    objs = sr.list_names()
+    ret = [ s for s in objs.keys() ]
+    return json_resp(json.dumps(ret))
+
+URL_NAMES = '/names/<name>'
+@blueprint.delete(URL_NAMES)
+def names_name_DEL(name):
+    sr = current_app.sr
+    objs = sr.list_names(name = name)
+    ids  = objs.get(name, [])
+    del_ids = list()
+    for _id in ids:
+        sr.delete_schema(_id = _id)
+        del_ids.append(_id)
+    ret = json.dumps(del_ids)
+    return json_resp(ret)
+
+URL_NAMES_VERSIONS_DIR = '/names/<name>/versions'
+@blueprint.get(URL_NAMES_VERSIONS_DIR)
+@blueprint.get('/subjects/<name>/versions')
+def names_name_versions_GET(name):
+    sr = current_app.sr
+    objs = sr.list_names(name = name)
+    ids  = objs.get(name)
+    return json_resp(json.dumps(ids))
+
+@blueprint.post(URL_NAMES_VERSIONS_DIR)
+@blueprint.post('/subjects/<name>/versions')
+def names_name_versions_POST(name):
+    sr = current_app.sr
+    obj = request.json # The JSON object in the PUT request
+    if not obj:
+        return f'Missing input JSON object', 500
+    s = Schema.from_dict(obj)
+    if s.name != name:
+        return f"Schema name ('{s.name}') does not match the name in the URL '({name})'", 500
+    sr.add_schema(s)
+    return json_resp(json.dumps({"id": s.id}))
+
+URL_DIGESTS_DIR = '/digests'
+@blueprint.get(URL_DIGESTS_DIR)
+def digests_GET():
+    # List by digests
+    sr = current_app.sr
+    objs = sr.list_digests()
+    ret = [ s for s in objs.keys() ]
+    return json_resp(json.dumps(ret))
+
+URL_DIGESTS_VERSIONS_DIR = '/digests/<digest>/versions'
+@blueprint.get(URL_DIGESTS_VERSIONS_DIR)
+def digests_digest_versions_GET(digest = ""):
+    digest = digest.lower()
+    sr = current_app.sr
+    objs = sr.list_digests(digest = digest)
+    ids  = objs.get(digest)
+    return json_resp(json.dumps(ids))
+
+# ------------ end blueprint ------------ #
+
+def srv_proc(app, listen, keyfile, certfile):
+    print("srv_proc BEGIN")
+    _SD.app = app
+    _SD.listen = listen
+    if keyfile and certfile:
+        srv = WSGIServer(listen, app, keyfile=keyfile, certfile=certfile)
+    else:
+        srv = WSGIServer(listen, app)
+    srv.serve_forever()
+    print("srv_proc END")
+
+class SimpleAuth(object):
+    def __init__(self, users):
+        if not users:
+            raise RuntimeError(f'No `users` were given')
+        _users = list()
+        for o in users:
+            if type(o) is dict:
+                # expecting {'username': _USERNAME_, 'password': _PASSWORD_ }
+                x = (o['username'], o['password'])
+            elif type(o) is list:
+                # expecting [ _USERNAME_, _PASSWORD_ ]
+                x = (o[0], o[1])
+            else:
+                # bad format
+                raise ValueError(f'Unknown username/password format: {o}')
+            _users.append(x)
+        self.users = set(_users)
+
+    def authorize(self):
+        # request is a special flask object referring to the current request
+        if not request.authorization:
+            return "Nope", 401
+        uname = request.authorization.get('username')
+        passwd = request.authorization.get('password')
+        if (uname, passwd) not in self.users:
+            return "Bad credentials", 401
+        return None # Good
+
+    @classmethod
+    def from_spec(cls, spec):
+        users = spec.get('users')
+        if not users:
+            raise RuntimeError(f'No `users` were listed in `auth`')
+        return SimpleAuth(users)
+
+
+AUTH_TBL = {
+        'simple': SimpleAuth,
+}
+
+def get_auth(auth_conf):
+    if not auth_conf:
+        return None
+    auth_type = auth_conf.get('type')
+    if not auth_type:
+        msg = f"`type` was not specified in the `auth` section"
+        log.error(msg)
+        raise RuntimeError(msg)
+    auth_cls = AUTH_TBL.get(auth_type)
+    if not auth_cls:
+        msg = f"`auth.type`: {auth_type} not found"
+        log.error(msg)
+        raise RuntimeError(msg)
+    auth_obj = auth_cls.from_spec(auth_conf)
+    return auth_obj
+
+class ValueType(enum.Enum):
+    CHAR = 1
+    U8   = 2
+    S8   = 3
+    U16  = 4
+    S16  = 5
+    U32  = 6
+    S32  = 7
+    U64  = 8
+    S64  = 9
+    F32  = 10
+    D64  = 11
+
+    CHAR_ARRAY = 12
+    U8_ARRAY   = 13
+    S8_ARRAY   = 14
+    U16_ARRAY  = 15
+    S16_ARRAY  = 16
+    U32_ARRAY  = 17
+    S32_ARRAY  = 18
+    U64_ARRAY  = 19
+    S64_ARRAY  = 20
+    F32_ARRAY  = 21
+    D64_ARRAY  = 22
+
+    LIST         = 23
+    LIST_ENTRY   = 24
+    RECORD_TYPE  = 25
+    RECORD_INST  = 26
+    RECORD_ARRAY = 27
+    TIMESTAMP    = 28
+
+    @classmethod
+    def from_json_str(cls, _str):
+        return STR_TYPE_TBL.get(_str)
+
+    def to_json_str(self):
+        return TYPE_STR_TBL[self]
+
+    @classmethod
+    def from_obj(cls, o):
+        typ = type(o)
+        if typ == ValueType:
+            return o
+        if typ == str:
+            return cls.from_json_str(o)
+        return ValueType(o)
+
+PRIM_TBL = {
+    # avro type
+    "int"    : ValueType.S32,
+    "long"   : ValueType.S64,
+    "float"  : ValueType.F32,
+    "double" : ValueType.D64,
+
+    # ldms types
+    "char" : ValueType.CHAR,
+    "u8"   : ValueType.U8,
+    "s8"   : ValueType.S8,
+    "u16"  : ValueType.U16,
+    "s16"  : ValueType.S16,
+    "u32"  : ValueType.U32,
+    "s32"  : ValueType.S32,
+    "u64"  : ValueType.U64,
+    "s64"  : ValueType.S64,
+    "f32"  : ValueType.F32,
+    "d64"  : ValueType.D64,
+}
+
+STR_TYPE_TBL = {
+    # avro type
+    "int"    : ValueType.S32,
+    "long"   : ValueType.S64,
+    "float"  : ValueType.F32,
+    "double" : ValueType.D64,
+
+    # ldms types
+    "char" : ValueType.CHAR,
+    "u8"   : ValueType.U8,
+    "s8"   : ValueType.S8,
+    "u16"  : ValueType.U16,
+    "s16"  : ValueType.S16,
+    "u32"  : ValueType.U32,
+    "s32"  : ValueType.S32,
+    "u64"  : ValueType.U64,
+    "s64"  : ValueType.S64,
+    "f32"  : ValueType.F32,
+    "d64"  : ValueType.D64,
+
+    "char[]" : ValueType.CHAR_ARRAY,
+    "u8[]"   : ValueType.U8_ARRAY,
+    "s8[]"   : ValueType.S8_ARRAY,
+    "u16[]"  : ValueType.U16_ARRAY,
+    "s16[]"  : ValueType.S16_ARRAY,
+    "u32[]"  : ValueType.U32_ARRAY,
+    "s32[]"  : ValueType.S32_ARRAY,
+    "u64[]"  : ValueType.U64_ARRAY,
+    "s64[]"  : ValueType.S64_ARRAY,
+    "f32[]"  : ValueType.F32_ARRAY,
+    "d64[]"  : ValueType.D64_ARRAY,
+
+    "record"   : ValueType.RECORD_TYPE,
+    "record[]" : ValueType.RECORD_ARRAY,
+
+    "list"   : ValueType.LIST,
+}
+
+ARRAY_TBL = {
+    # avro type
+    "int"    : ValueType.S32_ARRAY,
+    "long"   : ValueType.S64_ARRAY,
+    "float"  : ValueType.F32_ARRAY,
+    "double" : ValueType.D64_ARRAY,
+
+    # ldms types
+    "char" : ValueType.CHAR_ARRAY,
+    "u8"   : ValueType.U8_ARRAY,
+    "s8"   : ValueType.S8_ARRAY,
+    "u16"  : ValueType.U16_ARRAY,
+    "s16"  : ValueType.S16_ARRAY,
+    "u32"  : ValueType.U32_ARRAY,
+    "s32"  : ValueType.S32_ARRAY,
+    "u64"  : ValueType.U64_ARRAY,
+    "s64"  : ValueType.S64_ARRAY,
+    "f32"  : ValueType.F32_ARRAY,
+    "d64"  : ValueType.D64_ARRAY,
+
+    "char[]" : ValueType.CHAR_ARRAY,
+    "u8[]"   : ValueType.U8_ARRAY,
+    "s8[]"   : ValueType.S8_ARRAY,
+    "u16[]"  : ValueType.U16_ARRAY,
+    "s16[]"  : ValueType.S16_ARRAY,
+    "u32[]"  : ValueType.U32_ARRAY,
+    "s32[]"  : ValueType.S32_ARRAY,
+    "u64[]"  : ValueType.U64_ARRAY,
+    "s64[]"  : ValueType.S64_ARRAY,
+    "f32[]"  : ValueType.F32_ARRAY,
+    "d64[]"  : ValueType.D64_ARRAY,
+
+    "record"   : ValueType.RECORD_ARRAY,
+    "record[]" : ValueType.RECORD_ARRAY,
+
+    ValueType.CHAR : ValueType.CHAR_ARRAY,
+    ValueType.U8   : ValueType.U8_ARRAY,
+    ValueType.S8   : ValueType.S8_ARRAY,
+    ValueType.U16  : ValueType.U16_ARRAY,
+    ValueType.S16  : ValueType.S16_ARRAY,
+    ValueType.U32  : ValueType.U32_ARRAY,
+    ValueType.S32  : ValueType.S32_ARRAY,
+    ValueType.U64  : ValueType.U64_ARRAY,
+    ValueType.S64  : ValueType.S64_ARRAY,
+    ValueType.F32  : ValueType.F32_ARRAY,
+    ValueType.D64  : ValueType.D64_ARRAY,
+    ValueType.RECORD_TYPE  : ValueType.RECORD_ARRAY,
+
+    ValueType.CHAR_ARRAY : ValueType.CHAR_ARRAY,
+    ValueType.U8_ARRAY   : ValueType.U8_ARRAY,
+    ValueType.S8_ARRAY   : ValueType.S8_ARRAY,
+    ValueType.U16_ARRAY  : ValueType.U16_ARRAY,
+    ValueType.S16_ARRAY  : ValueType.S16_ARRAY,
+    ValueType.U32_ARRAY  : ValueType.U32_ARRAY,
+    ValueType.S32_ARRAY  : ValueType.S32_ARRAY,
+    ValueType.U64_ARRAY  : ValueType.U64_ARRAY,
+    ValueType.S64_ARRAY  : ValueType.S64_ARRAY,
+    ValueType.F32_ARRAY  : ValueType.F32_ARRAY,
+    ValueType.D64_ARRAY  : ValueType.D64_ARRAY,
+    ValueType.RECORD_ARRAY  : ValueType.RECORD_ARRAY,
+
+    ldms.LDMS_V_CHAR : ValueType.CHAR_ARRAY,
+    ldms.LDMS_V_U8   : ValueType.U8_ARRAY,
+    ldms.LDMS_V_S8   : ValueType.S8_ARRAY,
+    ldms.LDMS_V_U16  : ValueType.U16_ARRAY,
+    ldms.LDMS_V_S16  : ValueType.S16_ARRAY,
+    ldms.LDMS_V_U32  : ValueType.U32_ARRAY,
+    ldms.LDMS_V_S32  : ValueType.S32_ARRAY,
+    ldms.LDMS_V_U64  : ValueType.U64_ARRAY,
+    ldms.LDMS_V_S64  : ValueType.S64_ARRAY,
+    ldms.LDMS_V_F32  : ValueType.F32_ARRAY,
+    ldms.LDMS_V_D64  : ValueType.D64_ARRAY,
+    ldms.LDMS_V_RECORD_TYPE  : ValueType.RECORD_ARRAY,
+
+    ldms.LDMS_V_CHAR_ARRAY : ValueType.CHAR_ARRAY,
+    ldms.LDMS_V_U8_ARRAY   : ValueType.U8_ARRAY,
+    ldms.LDMS_V_S8_ARRAY   : ValueType.S8_ARRAY,
+    ldms.LDMS_V_U16_ARRAY  : ValueType.U16_ARRAY,
+    ldms.LDMS_V_S16_ARRAY  : ValueType.S16_ARRAY,
+    ldms.LDMS_V_U32_ARRAY  : ValueType.U32_ARRAY,
+    ldms.LDMS_V_S32_ARRAY  : ValueType.S32_ARRAY,
+    ldms.LDMS_V_U64_ARRAY  : ValueType.U64_ARRAY,
+    ldms.LDMS_V_S64_ARRAY  : ValueType.S64_ARRAY,
+    ldms.LDMS_V_F32_ARRAY  : ValueType.F32_ARRAY,
+    ldms.LDMS_V_D64_ARRAY  : ValueType.D64_ARRAY,
+    ldms.LDMS_V_RECORD_ARRAY  : ValueType.RECORD_ARRAY,
+
+}
+
+TYPE_STR_TBL = {
+    ValueType.CHAR : "char",
+    ValueType.U8   : "u8",
+    ValueType.S8   : "s8",
+    ValueType.U16  : "u16",
+    ValueType.S16  : "s16",
+    ValueType.U32  : "u32",
+    ValueType.S32  : "int",
+    ValueType.U64  : "u64",
+    ValueType.S64  : "s64",
+    ValueType.F32  : "f32",
+    ValueType.D64  : "d64",
+
+    ValueType.CHAR_ARRAY : "char[]",
+    ValueType.U8_ARRAY   : "u8[]",
+    ValueType.S8_ARRAY   : "s8[]",
+    ValueType.U16_ARRAY  : "u16[]",
+    ValueType.S16_ARRAY  : "s16[]",
+    ValueType.U32_ARRAY  : "u32[]",
+    ValueType.S32_ARRAY  : "int[]",
+    ValueType.U64_ARRAY  : "u64[]",
+    ValueType.S64_ARRAY  : "long[]",
+    ValueType.F32_ARRAY  : "float[]",
+    ValueType.D64_ARRAY  : "double[]",
+
+    ValueType.LIST  : "list",
+    ValueType.RECORD_TYPE  : "record",
+    ValueType.RECORD_ARRAY : "record[]",
+
+}
+
+ITEM_TYPE_TBL = {
+    # avro type
+    "int"    : ValueType.S32,
+    "long"   : ValueType.S64,
+    "float"  : ValueType.F32,
+    "double" : ValueType.D64,
+
+    # ldms types
+    "char" : ValueType.CHAR,
+    "u8"   : ValueType.U8,
+    "s8"   : ValueType.S8,
+    "u16"  : ValueType.U16,
+    "s16"  : ValueType.S16,
+    "u32"  : ValueType.U32,
+    "s32"  : ValueType.S32,
+    "u64"  : ValueType.U64,
+    "s64"  : ValueType.S64,
+    "f32"  : ValueType.F32,
+    "d64"  : ValueType.D64,
+
+    "char[]" : ValueType.CHAR,
+    "u8[]"   : ValueType.U8,
+    "s8[]"   : ValueType.S8,
+    "u16[]"  : ValueType.U16,
+    "s16[]"  : ValueType.S16,
+    "u32[]"  : ValueType.U32,
+    "s32[]"  : ValueType.S32,
+    "u64[]"  : ValueType.U64,
+    "s64[]"  : ValueType.S64,
+    "f32[]"  : ValueType.F32,
+    "d64[]"  : ValueType.D64,
+
+    "record"   : ValueType.RECORD_TYPE,
+    "record[]" : ValueType.RECORD_TYPE,
+
+    ValueType.CHAR : ValueType.CHAR,
+    ValueType.U8   : ValueType.U8,
+    ValueType.S8   : ValueType.S8,
+    ValueType.U16  : ValueType.U16,
+    ValueType.S16  : ValueType.S16,
+    ValueType.U32  : ValueType.U32,
+    ValueType.S32  : ValueType.S32,
+    ValueType.U64  : ValueType.U64,
+    ValueType.S64  : ValueType.S64,
+    ValueType.F32  : ValueType.F32,
+    ValueType.D64  : ValueType.D64,
+    ValueType.RECORD_TYPE  : ValueType.RECORD_TYPE,
+
+    ValueType.CHAR_ARRAY : ValueType.CHAR,
+    ValueType.U8_ARRAY   : ValueType.U8,
+    ValueType.S8_ARRAY   : ValueType.S8,
+    ValueType.U16_ARRAY  : ValueType.U16,
+    ValueType.S16_ARRAY  : ValueType.S16,
+    ValueType.U32_ARRAY  : ValueType.U32,
+    ValueType.S32_ARRAY  : ValueType.S32,
+    ValueType.U64_ARRAY  : ValueType.U64,
+    ValueType.S64_ARRAY  : ValueType.S64,
+    ValueType.F32_ARRAY  : ValueType.F32,
+    ValueType.D64_ARRAY  : ValueType.D64,
+    ValueType.RECORD_ARRAY  : ValueType.RECORD_TYPE,
+
+    ldms.LDMS_V_CHAR : ValueType.CHAR,
+    ldms.LDMS_V_U8   : ValueType.U8,
+    ldms.LDMS_V_S8   : ValueType.S8,
+    ldms.LDMS_V_U16  : ValueType.U16,
+    ldms.LDMS_V_S16  : ValueType.S16,
+    ldms.LDMS_V_U32  : ValueType.U32,
+    ldms.LDMS_V_S32  : ValueType.S32,
+    ldms.LDMS_V_U64  : ValueType.U64,
+    ldms.LDMS_V_S64  : ValueType.S64,
+    ldms.LDMS_V_F32  : ValueType.F32,
+    ldms.LDMS_V_D64  : ValueType.D64,
+    ldms.LDMS_V_RECORD_TYPE  : ValueType.RECORD_TYPE,
+
+    ldms.LDMS_V_CHAR_ARRAY : ValueType.CHAR,
+    ldms.LDMS_V_U8_ARRAY   : ValueType.U8,
+    ldms.LDMS_V_S8_ARRAY   : ValueType.S8,
+    ldms.LDMS_V_U16_ARRAY  : ValueType.U16,
+    ldms.LDMS_V_S16_ARRAY  : ValueType.S16,
+    ldms.LDMS_V_U32_ARRAY  : ValueType.U32,
+    ldms.LDMS_V_S32_ARRAY  : ValueType.S32,
+    ldms.LDMS_V_U64_ARRAY  : ValueType.U64,
+    ldms.LDMS_V_S64_ARRAY  : ValueType.S64,
+    ldms.LDMS_V_F32_ARRAY  : ValueType.F32,
+    ldms.LDMS_V_D64_ARRAY  : ValueType.D64,
+    ldms.LDMS_V_RECORD_ARRAY  : ValueType.RECORD_TYPE,
+}
+
+class SchemaMetric(object):
+    """Base for all metric definition"""
+
+    def __init__(self, name, _type, doc = None, is_meta = False, units = None,
+                 *args, **kwargs):
+        assert(_type is not None)
+        self.name = name
+        self.type = ValueType.from_obj(_type)
+        self.doc  = doc
+        self.units = units
+        self.is_meta = bool(is_meta)
+
+    @classmethod
+    def from_dict(cls, obj):
+        # Use specific class according to 'type'
+        _type = obj['type']
+        if _type == "array":
+            return SchemaMetricArray.from_dict(obj)
+        elif _type == "list":
+            return SchemaMetricList.from_dict(obj)
+        elif _type == "record":
+            return SchemaMetricRecord.from_dict(obj)
+        else:
+            return SchemaMetricPrimitive.from_dict(obj)
+        raise ValueError(f"Unknown type: {_type}")
+
+    @classmethod
+    def from_ldms_metric_template(cls, mt:ldms.MetricTemplate):
+        if mt.type == ldms.LDMS_V_RECORD_TYPE:
+            return SchemaMetricRecord.from_ldms_metric_template(mt)
+        elif mt.type == ldms.LDMS_V_RECORD_ARRAY:
+            return SchemaMetricRecordArray.from_ldms_metric_template(mt)
+        elif mt.type == ldms.LDMS_V_LIST:
+            return SchemaMetricList.from_ldms_metric_template(mt)
+        elif ldms.type_is_array(mt.type):
+            return SchemaMetricArray.from_ldms_metric_template(mt)
+        return SchemaMetricPrimitive.from_ldms_metric_template(mt)
+
+    @classmethod
+    def from_json(cls, obj):
+        if type(obj) is str:
+            obj = json.loads(obj)
+        return cls.from_dict(obj)
+
+    def as_json(self):
+        return json.dumps(self.as_dict())
+
+    def as_dict(self):
+        # Subclass shall override this
+        raise NotImplementedError()
+
+    def as_ldms_metric_desc(self):
+        # Subclass shall override this
+        raise NotImplementedError()
+
+    def update_digest(self, h):
+        h.update(self.name.encode())
+        h.update(self.type.value.to_bytes(4, 'little'))
+
+    def compatible(self, other):
+        raise NotImplementedError()
+
+
+class SchemaMetricPrimitive(SchemaMetric):
+    def __init__(self, name, _type, doc = None, is_meta = False, units = None):
+        super().__init__(name, _type, doc = doc, is_meta = is_meta, units = units)
+
+    @classmethod
+    def from_dict(cls, obj):
+        name = obj["name"]
+        _type = obj["type"]
+        doc = obj.get("doc")
+        is_meta = obj.get("is_meta")
+        units = obj.get("units")
+        return cls(name, _type, doc = doc, is_meta = is_meta, units = units)
+
+    @classmethod
+    def from_ldms_metric_template(cls, mt:ldms.MetricTemplate):
+        return cls(mt.name, mt.type, is_meta = mt.is_meta,
+                   units = mt.units)
+
+    def as_dict(self):
+        return {
+                "name": self.name,
+                "type": self.type.to_json_str(),
+                "is_meta" : self.is_meta,
+                "units" : self.units,
+                "doc": self.doc
+            }
+
+    def as_ldms_metric_desc(self):
+        ret = { "name": self.name, "metric_type": self.type.to_json_str() }
+        if self.is_meta:
+            ret['meta'] = self.is_meta
+        if self.units:
+            ret['units'] = self.units
+        return ret
+
+    def compatible(self, other):
+        return self.name == other.name and \
+               self.type == other.type and \
+               self.units == other.units and \
+               self.is_meta == other.is_meta
+
+
+class SchemaMetricArray(SchemaMetric):
+    def __init__(self, name, item_type, _len, is_meta = False, units = None, doc = None):
+        array_type = ARRAY_TBL.get(item_type)
+        super().__init__(name, array_type, doc = doc, is_meta = is_meta, units = units)
+        self.item_type = ITEM_TYPE_TBL.get(item_type)
+        self.len = _len
+
+    @classmethod
+    def from_dict(cls, obj):
+        name = obj['name']
+        _type = obj['type']
+        if _type != "array":
+            raise ValueError("not an 'array' type")
+        item_type = obj['items']
+        array_type = ARRAY_TBL.get(item_type)
+        if array_type == ValueType.RECORD_ARRAY:
+            return SchemaMetricRecordArray.from_dict(obj)
+        _len = obj.get('len', -1)
+        is_meta = obj.get('is_meta')
+        units = obj.get('units')
+        doc = obj.get('doc')
+        return cls(name, item_type, _len, is_meta = is_meta, units = units,
+                   doc = doc)
+
+    @classmethod
+    def from_ldms_metric_template(cls, mt:ldms.MetricTemplate):
+        return cls(mt.name, mt.type, mt.count, is_meta = mt.is_meta, units = mt.units)
+
+    def as_dict(self):
+        return {
+                "name": self.name,
+                "type": "array",
+                "is_meta" : self.is_meta,
+                "units" : self.units,
+                "doc" : self.doc,
+                "items": self.item_type.to_json_str(),
+                "len": self.len,
+            }
+
+    def as_ldms_metric_desc(self):
+        ret = { "name": self.name, "metric_type": self.type.to_json_str(),
+                "count": self.len }
+        if self.is_meta:
+            ret['meta'] = self.is_meta
+        if self.units:
+            ret['units'] = self.units
+        return ret
+
+    def compatible(self, other):
+        return self.name == other.name and \
+               self.type == other.type and \
+               self.item_type == other.item_type and \
+               self.len == other.len and \
+               self.units == other.units and \
+               self.is_meta == other.is_meta
+
+class SchemaMetricList(SchemaMetric):
+    def __init__(self, name, heap_sz, is_meta = False, units = None, doc = None):
+        super().__init__(name, ValueType.LIST, is_meta = is_meta, units = units, doc = doc)
+        self.heap_sz = heap_sz
+
+    @classmethod
+    def from_dict(cls, obj):
+        name = obj['name']
+        _type = obj['type']
+        if _type != "list":
+            raise ValueError("not a 'list' type")
+        heap_sz = obj.get('heap_sz', -1)
+        return cls(name, heap_sz)
+
+    @classmethod
+    def from_ldms_metric_template(cls, mt:ldms.MetricTemplate):
+        return cls(mt.name, mt.count, units = mt.units)
+
+    def as_dict(self):
+        return {
+                "name": self.name,
+                "type": "list",
+                "is_meta" : self.is_meta,
+                "units" : self.units,
+                "doc" : self.doc,
+                "heap_sz": self.heap_sz,
+            }
+
+    def as_ldms_metric_desc(self):
+        ret = { "name": self.name, "metric_type": self.type.to_json_str(),
+                "count": self.heap_sz }
+        if self.is_meta:
+            ret['meta'] = self.is_meta
+        if self.units:
+            ret['units'] = self.units
+        return ret
+
+    def compatible(self, other):
+        return self.name == other.name and \
+               self.type == other.type and \
+               self.units == other.units and \
+               self.is_meta == other.is_meta
+
+
+class SchemaMetricRecord(SchemaMetric):
+    def __init__(self, name, metrics, is_meta = True, units = None, doc = None):
+        super().__init__(name, ValueType.RECORD_TYPE,
+                         is_meta = is_meta, units = units, doc = doc)
+        self.metrics = metrics
+
+    @classmethod
+    def from_dict(self, json_obj):
+        _type = json_obj["type"]
+        if not _type:
+            raise ValueError(f"Missing 'type' attribute")
+        if _type != 'record':
+            raise ValueError(f"Expecting 'record' type but got '{_type}'")
+        name = json_obj.get("name")
+        if not name:
+            raise ValueError(f"Missing 'name' attribute")
+        fields = json_obj.get("fields")
+        if not fields:
+            raise ValueError(f"Missing 'fields' attribute")
+        metrics = list()
+        name_set = set()
+        for f in fields:
+            # name, doc, type
+            f_name = f.get('name')
+            f_type = f.get('type')
+            if not f_name:
+                raise ValueError(f"Missing 'name' attribute in the record field")
+            if not f_type:
+                raise ValueError(f"Missing 'type' attribute in the record field")
+            if f_name in name_set:
+                raise ValueError(f"Field '{f_name}' appeared multiple times")
+            name_set.add(f_name)
+            m = SchemaMetric.from_json(f)
+            metrics.append(m)
+        return SchemaMetricRecord(name, metrics)
+
+    @classmethod
+    def from_ldms_metric_template(cls, mt:ldms.MetricTemplate):
+        mlist = list()
+        for m in mt.rec_def:
+            _m = SchemaMetric.from_ldms_metric_template(m)
+            mlist.append(_m)
+        return cls(mt.name, mlist, is_meta = mt.is_meta, units = mt.units)
+
+    def as_dict(self):
+        return {
+                "name": self.name,
+                "type": "record",
+                "is_meta" : bool(self.is_meta),
+                "units" : self.units,
+                "doc" : self.doc,
+                "fields": [ m.as_dict() for m in self.metrics ],
+                }
+
+    def update_digest(self, h):
+        # digest the members first
+        for m in self.metrics:
+            m.update_digest(h)
+        h.update(self.name.encode())
+        h.update(self.type.value.to_bytes(4, 'little'))
+
+    def as_ldms_metric_desc(self):
+        mlist = [ m.as_ldms_metric_desc() for m in self.metrics ]
+        recdef = ldms.RecordDef(self.name, mlist)
+        ret = { "name": self.name, "metric_type": recdef }
+        if self.is_meta:
+            ret['meta'] = self.is_meta
+        if self.units:
+            ret['units'] = self.units
+        return ret
+
+    def compatible(self, other):
+        if type(other) != SchemaMetricRecord:
+            return False
+        if len(self.metrics) != len(other.metrics):
+            return False
+        for m0, m1 in zip(self.metrics, other.metrics):
+            if not m0.compatible(m1):
+                return False
+        return self.name == other.name and \
+               self.type == other.type and \
+               self.units == other.units and \
+               self.is_meta == other.is_meta
+
+
+class SchemaMetricRecordArray(SchemaMetricArray):
+    def __init__(self, name, record_type, _len, is_meta = False,
+                 units = None, doc = None):
+        super().__init__(name = name, item_type = "record",
+                         _len = _len, is_meta = is_meta, units = units,
+                         doc = doc)
+        self.record_type = record_type
+
+    @classmethod
+    def from_dict(cls, obj):
+        name = obj['name']
+        _type = obj['type']
+        if _type != "array":
+            raise ValueError("not an 'array' type")
+        item_type = obj['items']
+        array_type = ARRAY_TBL.get(item_type)
+        if array_type != ValueType.RECORD_ARRAY:
+            raise ValueError("Not a record array")
+        record_type = obj["record_type"]
+        _len = obj.get('len', -1)
+        is_meta = obj.get('is_meta')
+        units = obj.get('units')
+        doc = obj.get('doc')
+        return cls(name = name, record_type = record_type, _len = _len,
+                   is_meta = is_meta, units = units,
+                   doc = doc)
+
+    @classmethod
+    def from_ldms_metric_template(cls, mt:ldms.MetricTemplate):
+        assert(mt.type == ldms.LDMS_V_RECORD_ARRAY)
+        record_type = mt.rec_def.name
+        return cls(name = mt.name, record_type = record_type,
+                   _len = mt.count, is_meta = mt.is_meta, units = mt.units)
+
+    def as_dict(self):
+        return {
+                "name": self.name,
+                "type": "array",
+                "is_meta" : self.is_meta,
+                "units" : self.units,
+                "doc" : self.doc,
+                "items": "record",
+                "record_type": self.record_type,
+                "len": self.len,
+            }
+
+    def as_ldms_metric_desc(self, rec_def):
+        ret = { "name": self.name, "metric_type": "record[]", "count": self.len }
+        if self.is_meta:
+            ret['meta'] = self.is_meta
+        if self.units:
+            ret['units'] = self.units
+        if type(rec_def) != ldms.RecordDef:
+            raise TypeError(f"Type of `rec_def` must be RecordDef, got '{type(rec_def)}'")
+        ret['rec_def'] = rec_def
+        return ret
+
+
+class Schema(object):
+    def __init__(self, name:str, metrics:list, doc = None):
+        self.name = name
+        self.metrics = metrics
+        self.doc = doc
+
+    def as_dict(self):
+        """Return the Schema, encoded in JSON"""
+        return {
+                "schema": {
+                    "name": self.name,
+                    "type": "record",
+                    "doc" : self.doc,
+                    "fields": [ m.as_dict() for m in self.metrics ],
+                },
+             }
+
+    def as_ldms_schema(self):
+        sch = ldms.Schema(self.name)
+        _mdict = dict()
+        for m in self.metrics:
+            if m.type == ValueType.RECORD_ARRAY:
+                _rt = _mdict.get(m.record_type)
+                if _rt is None:
+                    raise ValueError(f"RECORD_ARRAY uses unknown RECORD_TYPE:" \
+                                     f" {m.record_type}")
+                rec_def = _rt['metric_type']
+                if type(rec_def) is not ldms.RecordDef:
+                    raise TypeError(f"RECORD_ARRAY refers to a non-record type")
+                _m = m.as_ldms_metric_desc(rec_def = rec_def)
+            else:
+                _m = m.as_ldms_metric_desc()
+            _mdict[m.name] = _m
+            sch.add_metric(**_m)
+        return sch
+
+    @classmethod
+    def from_ldms_schema(cls, sch:ldms.Schema):
+        mlist = list()
+        for mt in sch:
+            m = SchemaMetric.from_ldms_metric_template(mt)
+            mlist.append(m)
+        return cls(sch.name, mlist)
+
+    @classmethod
+    def from_ldms_set(cls, lset:ldms.Set):
+        n = len(lset)
+        mtlist = lset.get_metric_info(range(0, n))
+        mlist = [ SchemaMetric.from_ldms_metric_template(mt) for mt in mtlist ]
+        return cls(lset.schema_name, mlist)
+
+    def as_json(self):
+        return json.dumps(self.as_dict())
+
+    @classmethod
+    def from_json(cls, json_obj):
+        if type(json_obj) == bytes:
+            json_obj = json.loads(json_obj.decode())
+        elif type(json_obj) == str:
+            json_obj = json.loads(json_obj)
+        return cls.from_dict(json_obj)
+
+    @classmethod
+    def from_dict(cls, json_obj):
+        sch_def = json_obj.get("schema", json_obj)
+        _type = sch_def["type"]
+        # Expect only 'record' for now
+        # * The Apache Avro schema definition could be of other types, e.g.
+        #   array, or enum.
+        # * LDMS set schema is represented as AVRO 'record'
+        if _type != "record":
+            raise ValueError(f"Unsupported schema type: {_type}")
+        rec = SchemaMetricRecord.from_dict(sch_def)
+        return Schema(rec.name, rec.metrics, rec.doc)
+
+    @property
+    def digest(self):
+        h = hashlib.sha256()
+        for m in self.metrics:
+            m.update_digest(h)
+        return h.digest()
+
+    @property
+    def id(self):
+        return f"{self.name}-{self.digest.hex()}"
+
+    def compatible(self, other):
+        # Recursively compare everything, except 'heap_sz'
+        if len(self.metrics) != len(other.metrics):
+            return False
+        for m0, m1 in zip(self.metrics, other.metrics):
+            if not m0.compatible(m1):
+                return False
+        return True
+
+
+class EtcdProxy(object):
+    def __init__(self, etcd_list):
+        """Initialization
+
+        @param etcd_list(list): a list of `{'host': _HOST_, 'port': _PORT_}`
+        """
+        self.etcd = None
+        self.lock = threading.Lock()
+        self.etcd_idx = 0
+        self.etcd_list = etcd_list
+        self.__next_etcd_client()
+
+        proxy_fn_list = [ "get", "get_prefix", "put", "put_if_not_exists",
+                          "replace", "transaction", "delete", "delete_prefix" ]
+        for p in proxy_fn_list:
+            etcd_fn = getattr(etcd3.Etcd3Client, p)
+            self.__proxy_fn_wrap(p, etcd_fn)
+
+    def __proxy_fn_wrap(self, name, etcd_fn):
+        @wraps(etcd_fn)
+        def _proxy(*args, **kwargs):
+            self.lock.acquire()
+            n = len(self.etcd_list)
+            for i in range(0, n):
+                try:
+                    val = etcd_fn(self.etcd, *args, **kwargs)
+                except etcd3.Etcd3Exception as e:
+                    # Try next client when we encounter Etcd3Exception
+                    self.__next_etcd_client()
+                except Exception as e:
+                    # For other Exception, raise it
+                    self.lock.release()
+                    raise # re-raise the exception
+                else:
+                    break # success
+            else:
+                # All etcd failed
+                self.lock.release()
+                raise # re-raise the exception
+            self.lock.release()
+            return val
+        setattr(self, name, _proxy)
+
+    @property
+    def transactions(self):
+        return self.etcd.transactions
+
+    def __next_etcd_client(self):
+        # no lock
+        if self.etcd:
+            self.etcd.close()
+        member = self.etcd_list[self.etcd_idx]
+        self.etcd_idx += 1
+        self.etcd_idx %= len(self.etcd_list)
+        self.etcd = etcd3.client(host=member['host'], port=member['port'])
+        return self.etcd
+
+
+class SchemaRegistry(object):
+    def __init__(self, etcd_spec):
+        self.app = Flask(__name__)
+        self.app.url_map.strict_slashes = False # 'link' and 'link/' both work
+        self.app.sr = self # so that web app can use our resources
+        self.app.register_blueprint(blueprint)
+        etcd_list = etcd_spec.get('members', [{'host': 'localhost', 'port':'2379'}])
+        self.lock = threading.Lock()
+        sr_conf = etcd_spec.get('schema_registry', {'listen': '*.8080'} )
+        self.listen = sr_conf.get('listen', "*:8080")
+        self.srv_thr = None
+        self.keyfile = sr_conf.get('keyfile')
+        self.certfile = sr_conf.get('certfile')
+        self.etcd = EtcdProxy(etcd_list)
+        auth_conf = sr_conf.get('auth')
+        self.auth = get_auth(auth_conf)
+        self.etcd_prefix = sr_conf.get('etcd_prefix', '/schema-registry')
+        self._DIGESTS_PREFIX = f"{self.etcd_prefix}/index/digests"
+        self._NAMES_PREFIX = f"{self.etcd_prefix}/index/names"
+        self._OBJECTS_PREFIX = f"{self.etcd_prefix}/objects"
+
+    def start(self):
+        self.lock.acquire()
+        if self.srv_thr:
+            self.lock.release()
+            raise RuntimeError("HTTP server already running")
+        self.srv_thr = threading.Thread(target = srv_proc,
+                            kwargs = dict(app = self.app,
+                                          listen = self.listen,
+                                          keyfile = self.keyfile,
+                                          certfile = self.certfile))
+        self.srv_thr.start()
+        self.lock.release()
+
+    def join(self):
+        self.srv_thr.join()
+
+    def _digest_key(self, digest, _id):
+        digest_key = f"{self._DIGESTS_PREFIX}/{digest}/{_id}"
+        return digest_key
+
+    def _name_key(self, name, _id):
+        name_key = f"{self._NAMES_PREFIX}/{name}/{_id}"
+        return name_key
+
+    def _obj_key(self, _id):
+        obj_key = f"{self._OBJECTS_PREFIX}/{_id}"
+        return obj_key
+
+    def add_schema(self, sch:Schema):
+        js = sch.as_json()
+        # store the object
+        digest = sch.digest.hex()
+        _id = sch.id
+        obj_key = self._obj_key(_id)
+        obj_json = sch.as_json()
+        new_put = self.etcd.put_if_not_exists(obj_key, obj_json)
+        if not new_put:
+            return
+        # index by name
+        name_key = self._name_key(sch.name, _id)
+        self.etcd.put(name_key, f"{_id}")
+        # index by digest
+        digest_key = self._digest_key(digest, _id)
+        self.etcd.put(digest_key, f"{_id}")
+
+    def get_schema(self, _id):
+        key = f'{self._OBJECTS_PREFIX}/{_id}'
+        v, m = self.etcd.get(key)
+        if not v:
+            raise ValueError(f"Schema not found, id: {_id}")
+        return Schema.from_json(v.decode())
+
+    def list_names(self, name = None):
+        """Returns a `dict` of { '_SCHEMA_NAME_': [ _SCHEMA_IDS_ ] }"""
+        _name = f"{name}/" if name else ""
+        prefix = f"{self._NAMES_PREFIX}/{_name}"
+        g = self.etcd.get_prefix(prefix)
+        ret = dict()
+        for v, k in g:
+            prefix, name, _id = k.key.decode().rsplit('/', 2)
+            l = ret.setdefault(name, list())
+            l.append(v.decode())
+        return ret
+
+    def purge_database(self):
+        """Purge all data in etcd under 'self.etcd_prefix'"""
+        self.etcd.delete_prefix(self.etcd_prefix)
+
+    def delete_schema(self, _id):
+        name, digest = _id.rsplit('-', 1)
+        obj_key = self._obj_key(_id)
+        digest_key = self._digest_key(digest, _id)
+        name_key = self._name_key(name, _id)
+        for k in [obj_key, digest_key, name_key]:
+            self.etcd.delete(k)
+
+    def list_digests(self, digest = None):
+        """Returns a `dict` of { '_SCHEMA_DIGEST_': [ _SCHEMA_IDS_ ] }"""
+        _digest = f"{digest}/" if digest else ""
+        prefix = f"{self._DIGESTS_PREFIX}/{_digest}"
+        g = self.etcd.get_prefix(prefix)
+        ret = dict()
+        for v, k in g:
+            prefix, digest, _id = k.key.decode().rsplit('/', 2)
+            l = ret.setdefault(digest, list())
+            l.append(v.decode())
+        return ret
+
+
+class SchemaRegistryClient(object):
+    """SchemaRegistryClient(urls, auth = None, ca_cert = None)
+
+    A schema registry client to interact with the schema registry servers (over
+    HTTP/HTTPS).
+
+    :param urls: a list of schema registry server URls.
+    :param auth: an authentication object from `requests.auth` package.
+    :param ca_cert: an optional CA certificate for SSL/TLS verification. This is
+                    useful for self-signed certificate.
+    """
+    def __init__(self, urls, auth = None, ca_cert = None):
+        """
+        """
+        self._urls = list(urls)
+        self._uidx = 0
+        self.auth = auth
+        self.ca_cert = ca_cert
+
+    def _req(self, path, method = requests.get, json_obj = None):
+        n = len(self._urls)
+        while n:
+            prefix = self._urls[self._uidx]
+            url = f'{prefix}{path}'
+            kwargs = dict(url=url)
+            if self.auth:
+                kwargs['auth'] = self.auth
+            if self.ca_cert:
+                kwargs['verify'] = self.ca_cert
+            if json_obj:
+                kwargs['json'] = json_obj
+            try:
+                resp = method(**kwargs)
+            except:
+                # failed to send request to the server, retry with another URL
+                n -= 1
+                self._uidx = (self._uidx + 1) % len(self._urls)
+                continue
+            if not resp.ok:
+                # request completed with a not-OK status
+                raise RuntimeError(f'HTTP Response Status: {resp.status_code}')
+            return resp
+        # Reaching here means that we exhausted all URLs, just re-raise the
+        # latest exception.
+        raise
+
+    def get_schema(self, _id):
+        path   = URL_SCHEMAS_IDS.replace('<_id>', _id)
+        resp = self._req(path)
+        return Schema.from_json(resp.content)
+
+    def del_schema(self, _id):
+        """Delete schema"""
+        if not _id:
+            raise ValueError(f'`_id` parameter is required')
+        path   = URL_SCHEMAS_IDS.replace('<_id>', _id)
+        resp = self._req(path, method = requests.delete)
+        return resp
+
+    def add_schema(self, s:Schema):
+        resp = self._req("/", method = requests.post, json_obj = s.as_dict())
+        return resp
+
+    def delete_schema(self, _id):
+        return self.del_schema(_id)
+
+    def list_names(self):
+        resp = self._req(URL_NAMES_DIR)
+        objs = json.loads(resp.content.decode())
+        return objs
+
+    def list_versions(self, name=None, digest=None):
+        """List schema versions (IDs) by `name` or `digest`"""
+        if name:
+            if digest:
+                raise ValueError('Only `name` or `digest` paramter can be specified')
+            path = URL_NAMES_VERSIONS_DIR.replace('<name>', name)
+        elif digest:
+            path = URL_DIGESTS_VERSIONS_DIR.replace('<digest>', digest)
+        else:
+            raise ValueError('`name` or `digest` parameter is required')
+        resp = self._req(path)
+        objs = json.loads(resp.content.decode())
+        return objs
+
+    def list_digests(self):
+        resp = self._req(URL_DIGESTS_DIR)
+        objs = json.loads(resp.content.decode())
+        return objs
+
+
+if __name__ == '__main__':
+    # For running stand-alone schema_registry
+    import argparse
+    import yaml
+    logging.basicConfig()
+    parser = argparse.ArgumentParser(description="LDMS Schema Registry")
+    parser.add_argument('-c', '--cluster', required=True, metavar='ETCD_YAML',
+                        type=argparse.FileType('r'))
+    args = parser.parse_args()
+    etcd_spec = yaml.safe_load(args.cluster)
+
+    # schemaregistry
+    sr_config = etcd_spec.get('schema_registry')
+    if sr_config:
+        sr = SchemaRegistry(etcd_spec)
+        sr.start()
+        if False:
+            sr.purge_database()
+            o = open("/db/schema.json")
+            obj = json.load(o)
+            s = Schema.from_dict(obj)
+            print(f"digest: {s.digest.hex()}")
+            sr.add_schema(s)
+        sys.flags.interactive or sr.join()
+    else:
+        raise RuntimeError('schema_registry config section not found')


### PR DESCRIPTION
[x] SchemaRegistry server
    - integrated with maestro
    - can run as stand-alone (`python schema_registry.py _ARGS_`)
[x] C library
    - see `C/msr_client.h` for APIs
    - see `C/msr_test.c` for example usage
[x] Python Library
    [x] Convert to/from ldms.Schema
[x] record support
[x] list support
[x] array support
[x] passed `ldms-test/maestro_schema_registry_test` [x] doc