### PR TITLE
Add `None` to unit_strs mapping to support 'no units' case

### DIFF
--- a/src/maestro/maestro_util.py
+++ b/src/maestro/maestro_util.py
@@ -31,6 +31,7 @@ INT_ATTRS = [
 unit_strs = {
     'ms' : 1000,
     'us' : 1,
+    None : 1,
     'm' : 60000000,
     's' : 1000000,
     'h' : 3600000000,
@@ -74,7 +75,7 @@ def check_intrvl_str(interval_s):
     if type(interval_s) != str:
         raise ValueError(f"{error_str}")
     interval_s = interval_s.lower()
-    unit = next((unit for unit in unit_strs if unit in interval_s), None)
+    unit = next((unit for unit in unit_strs if unit and unit in interval_s), None)
     if unit:
         if interval_s.split(unit)[1] != '':
             raise ValueError(f"{error_str}")


### PR DESCRIPTION
Add `None` to unit_strs mapping to support 'no units' case. Otherwise, the `ival_s = float(ival_s) * unit_strs[unit]` at `maestro_util.py:86` will raise an exception.