### PR TITLE
Refactor 'credits' to 'quota' (due to OVIS-4 changes)

### DIFF
--- a/scripts/maestro
+++ b/scripts/maestro
@@ -916,13 +916,13 @@ def add_prdcr_listen(comms, prdcr_listen, aggregators, endpoints, agg_state):
             comm = comms[grp_name][agg_name]
             for pl in pl_dict:
                 rail = check_opt('rail', pl_dict[pl])
-                credits = check_opt('credits', pl_dict[pl])
+                quota = check_opt('quota', pl_dict[pl])
                 rx_rate = check_opt('rx_rate', pl_dict[pl])
                 regex = check_opt('regex', pl_dict[pl])
                 err, res = comm.prdcr_listen_add(pl,
                                                  pl_dict[pl]['reconnect'],
                                                  rail=rail,
-                                                 credits=credits,
+                                                 quota=quota,
                                                  rx_rate=rx_rate,
                                                  regex=regex,
                                                  disable_start=True)
@@ -957,7 +957,7 @@ def add_advertisers(comms, advertisers, endpoints):
             for host in expand_names(ad_dict['hosts']):
                 ad_name = f'{ad_names[0]}-{host}'
                 rail = check_opt('rail', ad_dict)
-                credits = check_opt('credits', ad_dict)
+                quota = check_opt('quota', ad_dict)
                 rx_rate = check_opt('rx_rate', ad_dict)
                 perm = check_opt('perm', ad_dict)
                 err, res = comm.advertiser_add(ad_name,
@@ -967,7 +967,7 @@ def add_advertisers(comms, advertisers, endpoints):
                                                ad_dict['reconnect'],
                                                auth=auth,
                                                rail=rail,
-                                               credits=credits,
+                                               quota=quota,
                                                rx_rate=rx_rate,
                                                perm=perm
                 )
@@ -1037,7 +1037,7 @@ def add_producers(comms, producers, aggregators, endpoints, agg_state):
                 hostname = endpoints[dmn_grp][dmn]['addr']
                 perm = check_opt('perm', prod)
                 rail = check_opt('rail', prod)
-                credits = check_opt('credits', prod)
+                quota = check_opt('quota', prod)
                 rx_rate = check_opt('rx_rate', prod)
                 if prod['type'] == 'bridge' or prod['type'] == 'advertiser':
                     prod_name = f'{agg_name}-{endpoint["port"]}'
@@ -1045,7 +1045,7 @@ def add_producers(comms, producers, aggregators, endpoints, agg_state):
                             prod_name, prod['type'],
                             endpoint['xprt'], hostname, endpoint['port'],
                             prod['reconnect'], auth=auth, perm=perm, rail=rail,
-                            credits=credits, rx_rate=rx_rate)
+                            quota=quota, rx_rate=rx_rate)
     return True
 
 def add_updaters(comms, updaters, aggregators, daemons, agg_state, rb=None):

--- a/scripts/maestro_ctrl
+++ b/scripts/maestro_ctrl
@@ -169,7 +169,7 @@ class ClusterCtrl(object):
         auth_name, plugin, auth_opt = check_auth(ad_grp)
         perm = check_opt('perm', ad_grp)
         rail = check_opt('rail', ad_grp)
-        credits = check_opt('credits', ad_grp)
+        quota = check_opt('quota', ad_grp)
         rx_rate = check_opt('rx_rate', ad_grp)
         ad_list = expand_names(spec['daemons'])
         self.advertisers[spec['daemons']] = {'names'     : ad_grp['names'],
@@ -182,7 +182,7 @@ class ClusterCtrl(object):
                                                              'plugin' : plugin },
                                              'perm'      : perm,
                                              'rail'      : rail,
-                                             'credits'   : credits,
+                                             'quota'     : quota,
                                              'rx_rate'   : rx_rate,
                                              'ad_list'   : ad_list
         }
@@ -196,11 +196,11 @@ class ClusterCtrl(object):
             node_listen = {}
             regex = check_opt('regex', pl)
             rail = check_opt('rail', pl)
-            credits = check_opt('credits', pl)
+            quota = check_opt('quota', pl)
             rx_rate = check_opt('rx_rate', pl)
             node_listen[pl['name']] = {'reconnect' : pl['reconnect'],
                                         'rail'      : rail,
-                                        'credits'   : credits,
+                                        'quota'     : quota,
                                         'rx_rate'   : rx_rate,
                                         'regex'     : regex
             }
@@ -288,7 +288,7 @@ class ClusterCtrl(object):
                     reconnect = check_intrvl_str(prod['reconnect'])
                     ports_per_dmn = len(endpoints) / len(smplr_dmns)
                     rx_rate = check_opt('rx_rate', prod)
-                    credits = check_opt('credits', prod)
+                    quota = check_opt('quota', prod)
                     rail = check_opt('rail', prod)
                     perm = check_opt('perm', prod)
                     ppd = ports_per_dmn
@@ -315,8 +315,8 @@ class ClusterCtrl(object):
                                 prod['rx_rate'] = rx_rate
                             if rail:
                                 prod['rail'] = rail
-                            if credits:
-                                prod['credits'] = credits
+                            if quota:
+                                prod['quota'] = quota
                             producers[group][endpoint] = prod
                     except Exception as e:
                         print(f'Error building producer config: {str(e)}\n'\
@@ -652,7 +652,7 @@ class ClusterCtrl(object):
                 interval = producer['reconnect']
                 rail = check_opt('rail', producer)
                 rx_rate = check_opt('rx_rate', producer)
-                credits = check_opt('credits', producer)
+                quota = check_opt('quota', producer)
                 fd.write(f'prdcr_add name={pname} '+
                          f'host={hostname} '+
                          f'port={port} '+
@@ -662,7 +662,7 @@ class ClusterCtrl(object):
                 self.write_opt_attr(fd, 'auth', auth, endline=False)
                 self.write_opt_attr(fd, 'rail', rail, endline=False)
                 self.write_opt_attr(fd, 'rx_rate', rx_rate, endline=False)
-                self.write_opt_attr(fd, 'credits', credits)
+                self.write_opt_attr(fd, 'quota', quota)
                 last_sampler = pname
                 if 'regex' in producer:
                     regex = True

--- a/src/maestro/maestro_util.py
+++ b/src/maestro/maestro_util.py
@@ -30,7 +30,7 @@ INT_ATTRS = [
 
 BYTE_ATTRS = [
     'rx_rate',
-    'credits'
+    'quota'
 ]
 
 unit_strs = {


### PR DESCRIPTION
https://github.com/ovis-hpc/ldms branch OVIS-4 recently refactor 'credits' to 'quota'. This is a patch to update maestro code to be compatible with ldms OVIS-4 branch.