### PR TITLE
Fix for new "producers" format in YAML configuration

### DIFF
--- a/scripts/maestro
+++ b/scripts/maestro
@@ -902,8 +902,11 @@ def add_updaters(comms, updaters, aggregators, daemons, agg_state, rb=None):
                 if rc:
                     if rc != 17:
                         print(f'Error {rc}: {msg} adding updater {updtr_name} to {agg_host["name"]}')
-                for regex in updtr['producers']:
-                    comm.updtr_prdcr_add(agg_updtr, regex['regex'])
+                if type(updtr['producers'] is list:
+                    for regex in updtr['producers']:
+                        comm.updtr_prdcr_add(agg_updtr, regex)
+                else:
+                    comm.updtr_prdcr_add(agg_updtr, updtr['producers'])
                 # Ability for yaml defined set instance matching is removed, as rebalacing is now done
                 # across sets, rather than producers
                 if rb == 'sets':


### PR DESCRIPTION
Pass "local" path as argument when calling "local_mode" method