### PR TITLE
maestro will connect to all daemons in YAML file unless maestro_comm set to False

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ daemons:
     endpoints :
       - names : &sampler-endpoints "node-[1-8]-[10002-10003]"
         ports : &sampler-ports "[10002-10003]"
-        maestro_comm : True
+        maestro_comm : True # If omitted, defaults to True
         xprt  : sock
         auth  :
            name : ovis1

--- a/scripts/maestro
+++ b/scripts/maestro
@@ -248,7 +248,8 @@ class MaestroMonitor(object):
             for ep_name in self.daemons[dmn_name]['endpoints']:
                 ep = self.daemons[dmn_name]['endpoints'][ep_name]
                 hostname = self.daemons[dmn_name]['addr']
-                if 'maestro_comm' not in ep:
+                mc = check_opt('maestro_comm', ep)
+                if mc is False or mc == 'false' or mc == 'False':
                     listen.append(ep)
                     continue
                 conf = check_opt('conf', ep)


### PR DESCRIPTION
False, "false", and "False" are accepted
Previously maestro would refrain from connecting to LDMS daemons unless maestro_comm was set to True. If maestro_comm is omitted from the configuration, maestro will assume "maestro_comm" to be True, and attempt to establish a connection.