### PR TITLE
Bug fix in the event a sampler isn't being monitored/configured by maestro

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ Maestro consumes configuration files in YAML format.
 
 Here's an example of an _etcd_ cluster configuration:
 
+NOTE: etcd will not store values that are listed as None, null, or 0. If you
+would like to ensure these values are stored to the etcd database, you can
+represent them as strings.
+
+e.g. "key" : "0"
+
 ```yaml
 cluster: voltrino
 members:

--- a/scripts/maestro
+++ b/scripts/maestro
@@ -307,6 +307,8 @@ class MaestroMonitor(object):
         for dmn_grp in self.samplers:
             cfg_smplrs = {}
             for sampler in expand_names(dmn_grp):
+                if 'maestro_comm' not in self.daemons[sampler]:
+                    continue
                 if self.comms[sampler].state == 3:
                     print(f'Unable to connect to ldms daemon {sampler}')
                     continue

--- a/scripts/maestro_ctrl
+++ b/scripts/maestro_ctrl
@@ -164,7 +164,7 @@ if __name__ == "__main__":
     cluster = MaestroCtrl(client, args.prefix, conf_spec, args)
 
     if args.daemon_name:
-        ldmsd_cfg_str = cluster.daemon_config(args.ldms_config, args.daemon_name.rstrip('0'))
+        ldmsd_cfg_str = cluster.daemon_config(args.ldms_config, args.daemon_name)
         print(f'{ldmsd_cfg_str}')
         sys.exit(0)
     if args.local:


### PR DESCRIPTION
Bug fix in the event a sampler isn't being monitored/configured by maestro

Update documentation regarding etcd omitting None, null, and 0 None, null, or 0 must be passed as strings to be stored in an etcd database Remove rstrip from maestro_ctrl when "daemon_name" parameter option is invoked