### PR TITLE
Load all YAML values as strings in maestro_ctrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,6 @@ Maestro consumes configuration files in YAML format.
 
 Here's an example of an _etcd_ cluster configuration:
 
-NOTE: etcd will not store values that are listed as None, null, or 0. If you
-would like to ensure these values are stored to the etcd database, you can
-represent them as strings.
-
-e.g. "key" : "0"
-
 ```yaml
 cluster: voltrino
 members:

--- a/scripts/maestro_ctrl
+++ b/scripts/maestro_ctrl
@@ -136,7 +136,7 @@ if __name__ == "__main__":
         import sys
         sys.tracebacklimit=0
     config_fp = open(args.ldms_config)
-    conf_spec = yaml.safe_load(config_fp)
+    conf_spec = yaml.load(config_fp, Loader=yaml.BaseLoader)
 
     if args.cluster:
         # All keys in the DB are prefixed with the prefix name. So we can


### PR DESCRIPTION
Loads YAML file values as strings when using maestro_ctrl
Resolves issue with etcd that resulted in etcd not loading certain type values into the database

Resolves #115